### PR TITLE
Ttt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ FastPLMs is an open-source initiative dedicated to making protein language model
 3. [Supported Models](#supported-models)
 4. [Attention Backends](#attention-backends)
 5. [Embedding & Pooling](#embedding--pooling)
-6. [Concrete Examples](#concrete-examples)
-7. [Testing & Benchmarking](#testing--benchmarking)
-8. [Installation & Docker](#installation--docker)
+6. [Experimental Test-Time Training](#experimental-test-time-training)
+7. [Concrete Examples](#concrete-examples)
+8. [Testing & Benchmarking](#testing--benchmarking)
+9. [Installation & Docker](#installation--docker)
 
 ---
 
@@ -61,11 +62,11 @@ We maintain a comprehensive [HuggingFace Collection](https://huggingface.co/coll
 | **ESM2** | Meta AI | [facebookresearch/esm](https://github.com/facebookresearch/esm) | Flash (SDPA) / Flex Attention | 8M, 35M, 150M, 650M, 3B |
 | **ESM++** | Biohub | [Biohub/esm](https://github.com/Biohub/esm) | Optimized SDPA / Flex | Small (300M), Large (600M), 6B |
 | **ESM3** | Biohub | [Biohub/esm](https://github.com/Biohub/esm) | HF AutoModel wrapper | Open Small |
-| **ESMFold2** | Biohub | [Biohub/esm](https://github.com/Biohub/esm) | Self-contained HF AutoModel wrapper | Full, Fast, Experimental, Cutoff2025 |
+| **ESMFold2** | Biohub | [Biohub/esm](https://github.com/Biohub/esm) | Self-contained HF AutoModel wrapper, opt-in experimental TTT | Full, Fast, Experimental, Cutoff2025 |
 | **DPLM** | ByteDance | [bytedance/dplm](https://github.com/bytedance/dplm) | Diffusion Optimized Attention | 150M, 650M, 3B |
 | **DPLM2** | ByteDance | [bytedance/dplm](https://github.com/bytedance/dplm) | Multimodal Diffusion | 150M, 650M, 3B |
 | **ANKH** | Elnaggar Lab | [ElnaggarLab/ankh](https://huggingface.co/ElnaggarLab/ankh-base) | T5 RPE via Flex score_mod | Base, Large, ANKH2-L, ANKH3-L, ANKH3-XL |
-| **ESMFold** | Meta AI | [facebookresearch/esm](https://github.com/facebookresearch/esm) | ProteinTTT + Fast ESM2 backbone | Standard |
+| **ESMFold** | Meta AI | [facebookresearch/esm](https://github.com/facebookresearch/esm) | Fast ESM2 backbone, opt-in experimental ProteinTTT | Standard |
 | **Boltz2** | MIT / Various | [jwohlwend/boltz](https://github.com/jwohlwend/boltz) | Optimized Structure Prediction | Standard |
 
 ### Full Model List
@@ -103,6 +104,75 @@ We maintain a comprehensive [HuggingFace Collection](https://huggingface.co/coll
 | `ankh3_xl` | ANKH | 3.49B | Elnaggar Lab | [Synthyra/ANKH3_xl](https://huggingface.co/Synthyra/ANKH3_xl) | [ElnaggarLab/ankh3-xl](https://huggingface.co/ElnaggarLab/ankh3-xl) |
 | `esmfold` | ESMFold | 3.53B | Meta AI | [Synthyra/FastESMFold](https://huggingface.co/Synthyra/FastESMFold) | [facebookresearch/esm](https://github.com/facebookresearch/esm) |
 | `boltz2` | Boltz2 | 506.3M | MIT / Various | [Synthyra/Boltz2](https://huggingface.co/Synthyra/Boltz2) | [jwohlwend/boltz](https://github.com/jwohlwend/boltz) |
+
+---
+
+## Experimental Test-Time Training
+
+FastPLMs includes experimental ProteinTTT-style test-time training utilities for
+sequence PLMs and the PLM backbones used by ESMFold and ESMFold2. TTT is
+disabled by default. Normal `from_pretrained`, `forward`, `embed_dataset`,
+`fold_protein`, and `state_dict()` behavior is unchanged unless you explicitly
+call `ttt()`, `fold_protein(..., ttt=True)`, or `fold_protein_ttt()`.
+
+TTT briefly adapts a model to one input protein using masked language modeling
+and local LoRA adapters. It can improve predictions for difficult or
+low-confidence proteins, especially structure predictions with weak baseline
+pLDDT, but it is not guaranteed to help. It adds GPU memory use and runtime,
+can degrade already confident predictions, and should be treated as an
+experimental test-time compute option.
+
+Supported opt-in paths:
+
+| Model family | TTT API | Notes |
+| :--- | :--- | :--- |
+| ESM2, ESM++, ESM3, E1, DPLM, DPLM2, ANKH | `model.ttt(seq=...)` | MLM LoRA adaptation of the PLM backbone only |
+| FastESMFold | `model.fold_protein(sequence, ttt=True)` or `model.fold_protein_ttt(sequence)` | Returns the best pLDDT fold across baseline and TTT steps |
+| ESMFold2 | `model.fold_protein(sequence, ttt=True, ttt_config=...)` or `model.fold_protein_ttt(sequence)` | Protein-only v1 path, trains LoRA only on `_esmc` |
+| Boltz2 | Not supported | Boltz2 remains inference-only in FastPLMs |
+
+Sequence PLM example:
+
+```python
+from transformers import AutoModelForMaskedLM
+
+model = AutoModelForMaskedLM.from_pretrained(
+    "Synthyra/ESM2-8M",
+    trust_remote_code=True,
+).cuda().eval()
+
+# No adapters are injected until this call.
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+```
+
+ESMFold2 example:
+
+```python
+from transformers import AutoModel
+
+model = AutoModel.from_pretrained(
+    "Synthyra/ESMFold2-Fast",
+    trust_remote_code=True,
+    load_esmc=True,
+).cuda().eval()
+
+result = model.fold_protein(
+    "MSTNPKPQRKTKRNT",
+    num_loops=1,
+    num_sampling_steps=10,
+    ttt=True,
+    ttt_config={"steps": 1, "ags": 1, "batch_size": 1},
+)
+print(result.ttt_metrics)
+```
+
+If you use the TTT functionality, cite ProteinTTT in addition to FastPLMs and
+the underlying model papers. The ProteinTTT citation is listed in
+[Citations](#esmfold--proteinttt).
 
 ---
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -4,6 +4,14 @@ This document covers each model family supported by FastPLMs: loading, configura
 
 Most sequence models (ESM2, ESM++, E1, DPLM, DPLM2, ANKH) share the same embedding pipeline via `EmbeddingMixin`. ESM3 exposes its own compatible `embed_dataset()` method for sequence embeddings. They support most attention backends, with these exceptions: ANKH supports only `sdpa` and `flex`, and ESM3 supports `sdpa` and `flex`. Structure prediction models (Boltz2, ESMFold, ESMFold2, and ESMFold2-Fast) have their own APIs.
 
+Experimental test-time training (TTT) is available for ESM2, ESM++, ESM3, E1,
+DPLM, DPLM2, ANKH, FastESMFold, and ESMFold2. It is disabled by default and is
+only activated by explicit calls such as `model.ttt(...)`,
+`fold_protein(..., ttt=True)`, or `fold_protein_ttt(...)`. TTT trains small
+LoRA adapters with a masked language modeling objective on the test protein. It
+can improve difficult or low-confidence cases, but it adds test-time compute and
+can degrade already strong predictions. Treat it as experimental.
+
 ---
 
 ## ESM2
@@ -33,6 +41,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/ESM2-150M", config=config
 - Backend can be set on the config before `from_pretrained` OR via the mutable `model.attn_backend` property after load (same mechanism as every other family).
 - Pre-LayerNorm architecture with a final `emb_layer_norm_after`
 - Supports `output_attentions=True` and `output_hidden_states=True`
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; no LoRA adapters are injected during normal inference.
 
 ### Available Checkpoints
 
@@ -67,6 +76,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/ESMplusplus_small", trust
 - Uses `einops` for tensor reshaping operations
 - Rotary embeddings support `interleaved` mode and `scale_base`/`scaling_factor` for dynamic scaling
 - Backend can be set on the config before `from_pretrained` OR via the mutable `model.attn_backend` property after load.
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; it adapts the PLM backbone only.
 
 ### Batched Forward Pass
 
@@ -131,6 +141,7 @@ model = AutoModel.from_pretrained(
 - Supports `embed_dataset()` with pooled `mean`, `cls`, and `max` embeddings, plus residue-wise embeddings through `full_embeddings=True`.
 - Supports `sdpa` and `flex` attention backends.
 - Includes the Biohub ESM MIT license in the Hub `LICENSE` file and model card metadata.
+- Experimental TTT is opt-in via `model.ttt(seq=...)` and uses `sequence_logits` only.
 
 ### Available Checkpoints
 
@@ -165,6 +176,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/Profluent-E1-150M", trust
 - Separate RoPE configurations for within-sequence and global attention (different `rope_theta`)
 - KV caching via `DynamicCache` for efficient generation
 - Backend can be set on the config before `from_pretrained` OR via the mutable `model.attn_backend` property after load.
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; the E1 path carries `input_ids`, `within_seq_position_ids`, `global_position_ids`, and `sequence_ids`.
 
 ### Tokenization (Sequence Mode)
 
@@ -258,6 +270,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/DPLM-150M", trust_remote_
 - Architecture extends `EsmConfig` and `EsmPreTrainedModel` from HuggingFace
 - Supports cross-attention and KV caching for generation
 - `ModifiedEsmSelfAttention` extends the official `EsmSelfAttention` with multi-backend support
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; normal DPLM inference and diffusion APIs are unchanged.
 
 ### Post-Load Backend Switching
 
@@ -298,6 +311,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/DPLM2-150M", trust_remote
 - Special token normalization: `_normalize_dplm2_input_ids()` maps tokens above vocab_size back into range
 - Packed multimodal layout detection: `_has_packed_multimodal_layout()` checks if input_ids contain interleaved AA and structure tokens
 - The official DPLM2 has an extra `contact_head` not present in the FastPLM version, so weight compliance testing is skipped for this family
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; it adapts only LoRA weights on the PLM backbone.
 
 ### Available Checkpoints
 
@@ -339,6 +353,7 @@ model = AutoModelForMaskedLM.from_pretrained("Synthyra/ANKH_base", config=config
 - Layer 0 owns the relative-position-bias `nn.Embedding`; subsequent layers receive the precomputed bias through the forward call.
 - The native ANKH checkpoint is a T5 encoder-decoder; FastPLMs uses the encoder only and bolts on a separate `lm_head` for the `ForMaskedLM` variant. For weight-parity comparisons against `transformers.T5EncoderModel`, the FastPLMs `lm_head.weight` is allowlisted as an expected extra parameter.
 - ANKH3 checkpoints use 256-token tokenizers, while ANKH v1/v2 checkpoints use 144-token tokenizers. Use the checkpoint tokenizer through `model.tokenizer` or `AutoTokenizer.from_pretrained(<checkpoint>)`.
+- Experimental TTT is opt-in via `model.ttt(seq=...)`; the ANKH MaskedLM head is not pretrained for standard MLM, so results should be treated especially cautiously.
 
 ### Available Checkpoints
 
@@ -373,6 +388,7 @@ model = AutoModel.from_pretrained("Synthyra/Boltz2", trust_remote_code=True, dty
 - Custom featurization pipeline via `minimal_featurizer.build_boltz2_features()`
 - Outputs atomic coordinates, pLDDT, pTM, ipTM confidence scores
 - Can export predictions as CIF files via `model.save_as_cif(output, "pred.cif")`
+- TTT is not supported for Boltz2 in FastPLMs.
 
 ### Predict Structure
 
@@ -423,6 +439,9 @@ model = AutoModel.from_pretrained(
 - Final scoring can report pTM, iPTM, pLDDT, structures, and distogram logits.
 - `set_kernel_backend()`, `set_chunk_size()`, and `apply_torch_compile()` are
   available on the ESMFold2 wrappers.
+- Experimental TTT is opt-in via `fold_protein(..., ttt=True)` or
+  `fold_protein_ttt(...)`; it trains LoRA adapters only on `_esmc`, not the
+  folding trunk, confidence head, or diffusion head.
 
 ### Available Checkpoints
 
@@ -472,7 +491,7 @@ metrics, pI filtering, optional scaling critics, and caveats.
 ## ESMFold
 
 **Organization:** Meta AI (wrapped by Synthyra)
-**Architecture:** ESM2 backbone + structure module with optional Test-Time Training (TTT)
+**Architecture:** ESM2 backbone + structure module with optional experimental Test-Time Training (TTT)
 **Checkpoints:** Standard
 
 ### Loading
@@ -487,8 +506,9 @@ model = AutoModel.from_pretrained("Synthyra/FastESMFold", trust_remote_code=True
 
 - Inherits from `transformers.EsmForProteinFolding` with the ESM2 backbone replaced by `FastEsmBackbone`
 - Supports all attention backends via `config.attn_backend`
-- Optional Test-Time Training (TTT): Adapts the ESM2 backbone via LoRA + masked LM before folding
-- TTT typically improves low-confidence sequences (baseline pLDDT < 0.5) by 10-30+ points
+- TTT is disabled by default and must be requested with `ttt=True` or `fold_protein_ttt(...)`
+- Optional experimental TTT adapts the ESM2 backbone via LoRA + masked LM before folding
+- TTT can improve low-confidence sequences, but it adds compute and may degrade already strong predictions
 
 ### Structure Prediction
 
@@ -498,17 +518,19 @@ with torch.no_grad():
     output = model.infer("MKTLLILAVVAAALA")
 pdb_string = model.output_to_pdb(output)
 
-# With TTT (default: 10 optimizer steps)
-result = model.fold_protein("MKTLLILAVVAAALA")
+# With experimental TTT (default: 10 optimizer steps)
+result = model.fold_protein("MKTLLILAVVAAALA", ttt=True)
 # result = {"plddt": float, "ptm": float, "pdb_string": str, ...}
 ```
 
-### Disabling TTT
+### TTT Defaults
+
+TTT is disabled by default. Standard `fold_protein(...)` is a baseline fold and
+returns `best_step=0`. You can also call `model.infer(...)` directly for raw
+ESMFold outputs. Use `model._ttt_cfg` to tune optimizer steps, LoRA rank, and
+masking parameters before calling `fold_protein(..., ttt=True)`.
 
 ```python
-from transformers import AutoConfig, AutoModel
-
-config = AutoConfig.from_pretrained("Synthyra/FastESMFold", trust_remote_code=True)
-config.ttt_config = {"steps": 0}
-model = AutoModel.from_pretrained("Synthyra/FastESMFold", config=config, trust_remote_code=True)
+model._ttt_cfg.steps = 3
+result = model.fold_protein_ttt("MKTLLILAVVAAALA")
 ```

--- a/fastplms/ankh/README.md
+++ b/fastplms/ankh/README.md
@@ -41,6 +41,31 @@ outputs = model(**inputs)
 embeddings = outputs.last_hidden_state  # (batch, seq_len, hidden_dim)
 ```
 
+## Experimental Test-Time Training
+
+TTT is disabled by default. Normal ANKH inference, embeddings, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+with masked language modeling on the test protein. ANKH's FastPLMs MaskedLM
+head is encoder-only and not pretrained for standard MLM, so treat TTT results
+with extra caution.
+
+```python
+from transformers import AutoModelForMaskedLM
+
+mlm = AutoModelForMaskedLM.from_pretrained(
+    "Synthyra/ANKH_base",
+    trust_remote_code=True,
+).cuda().eval()
+
+metrics = mlm.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+mlm.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Batch Embedding
 
 ```python

--- a/fastplms/ankh/modeling_ankh.py
+++ b/fastplms/ankh/modeling_ankh.py
@@ -21,6 +21,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -677,7 +678,7 @@ class FastAnkhModel(AnkhPreTrainedModel, EmbeddingMixin):
         )
 
 
-class FastAnkhForMaskedLM(AnkhPreTrainedModel, EmbeddingMixin):
+class FastAnkhForMaskedLM(FastPLMTestTimeTrainingMixin, AnkhPreTrainedModel, EmbeddingMixin):
     """ANKH encoder with LM head for masked language modeling.
 
     NOTE: The LM head is initialized from the shared embedding weights but is NOT
@@ -694,6 +695,7 @@ class FastAnkhForMaskedLM(AnkhPreTrainedModel, EmbeddingMixin):
         self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
         self.loss_fct = nn.CrossEntropyLoss()
         self.post_init()
+        self.init_ttt({"lora_target_replace_module": "AnkhSelfAttention"})
 
     @property
     def tokenizer(self):
@@ -724,6 +726,29 @@ class FastAnkhForMaskedLM(AnkhPreTrainedModel, EmbeddingMixin):
             hidden_state_index=hidden_state_index,
             store_all_hidden_states=store_all_hidden_states,
         )
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.encoder]
+
+    def _ttt_tokenize(
+        self,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs
+        if input_ids is not None:
+            return input_ids
+        assert seq is not None, "Pass either seq or input_ids for ANKH TTT."
+        sequences = [seq] if isinstance(seq, str) else seq
+        spaced_sequences = [" ".join(sequence) for sequence in sequences]
+        tokenized = self.tokenizer(spaced_sequences, return_tensors="pt", padding=True)
+        return tokenized["input_ids"]
+
+    def _ttt_replacement_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        amino_acids = "ACDEFGHIKLMNPQRSTVWY"
+        ids = [self.tokenizer.convert_tokens_to_ids(aa) for aa in amino_acids]
+        return torch.tensor(ids, device=input_ids.device, dtype=input_ids.dtype)
 
     def forward(
         self,

--- a/fastplms/boltz/README.md
+++ b/fastplms/boltz/README.md
@@ -87,6 +87,7 @@ The export directory contains:
 ## Limitations
 - Current featurization path is protein-only and minimal.
 - This implementation is meant for practical inference and export workflows, not full Boltz training parity.
+- Test-time training is not supported for Boltz2 in FastPLMs. TTT is currently limited to sequence PLMs plus ESMFold and ESMFold2 PLM backbones.
 
 ## Docker-first compliance testing
 

--- a/fastplms/dplm/README.md
+++ b/fastplms/dplm/README.md
@@ -36,6 +36,24 @@ with torch.no_grad():
     logits = mlm(**batch).logits
 ```
 
+## Experimental test-time training
+
+TTT is disabled by default. Normal DPLM inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the PLM backbone with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions.
+
+```python
+metrics = mlm.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+mlm.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Attention backends
 
 `sdpa` (PyTorch Scaled Dot Product Attention) is the default.

--- a/fastplms/dplm/modeling_dplm.py
+++ b/fastplms/dplm/modeling_dplm.py
@@ -52,6 +52,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -735,7 +736,7 @@ class DPLMModel(DPLMPreTrainedModel, EmbeddingMixin):
         )
 
 
-class DPLMForMaskedLM(DPLMPreTrainedModel, EmbeddingMixin):
+class DPLMForMaskedLM(FastPLMTestTimeTrainingMixin, DPLMPreTrainedModel, EmbeddingMixin):
     config_class = DPLMConfig
 
     def __init__(self, config, dropout: float = 0.1):
@@ -759,6 +760,7 @@ class DPLMForMaskedLM(DPLMPreTrainedModel, EmbeddingMixin):
         self.eos_id = self.tokenizer.eos_token_id
         self.x_id = self.tokenizer.convert_tokens_to_ids("X")
         self.contact_head = None
+        self.init_ttt({"lora_target_replace_module": "ModifiedEsmAttention"})
 
     def get_input_embeddings(self) -> nn.Module:
         return self.esm.get_input_embeddings()
@@ -785,6 +787,9 @@ class DPLMForMaskedLM(DPLMPreTrainedModel, EmbeddingMixin):
 
     def predict_contacts(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         return self.esm.predict_contacts(input_ids, attention_mask=attention_mask)
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.esm]
 
     def forward(
         self,

--- a/fastplms/dplm2/README.md
+++ b/fastplms/dplm2/README.md
@@ -36,6 +36,24 @@ with torch.no_grad():
     logits = mlm(**batch).logits
 ```
 
+## Experimental test-time training
+
+TTT is disabled by default. Normal DPLM2 inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the PLM backbone with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions.
+
+```python
+metrics = mlm.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+mlm.ttt_reset()
+print(metrics["losses"])
+```
+
 ## DPLM2 modality types
 DPLM2 infers `type_ids` automatically from `input_ids` and `attention_mask` when they are not provided.
 

--- a/fastplms/dplm2/modeling_dplm2.py
+++ b/fastplms/dplm2/modeling_dplm2.py
@@ -52,6 +52,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -685,7 +686,7 @@ class DPLM2Model(DPLM2PreTrainedModel, EmbeddingMixin):
         )
 
 
-class DPLM2ForMaskedLM(DPLM2PreTrainedModel, EmbeddingMixin):
+class DPLM2ForMaskedLM(FastPLMTestTimeTrainingMixin, DPLM2PreTrainedModel, EmbeddingMixin):
     config_class = DPLM2Config
     def __init__(self, config, dropout: float = 0.1, vocab_size: Optional[int] = None):
         config.hidden_dropout_prob = dropout
@@ -701,6 +702,7 @@ class DPLM2ForMaskedLM(DPLM2PreTrainedModel, EmbeddingMixin):
         self.tokenizer = self.__class__.tokenizer
         if isinstance(config._name_or_path, str) and len(config._name_or_path) > 0:
             self.tokenizer = EsmTokenizer.from_pretrained(config._name_or_path)
+        self.init_ttt({"lora_target_replace_module": "ModifiedEsmAttention"})
 
     def get_input_embeddings(self) -> nn.Module:
         return self.esm.get_input_embeddings()
@@ -739,6 +741,9 @@ class DPLM2ForMaskedLM(DPLM2PreTrainedModel, EmbeddingMixin):
             hidden_state_index=hidden_state_index,
             store_all_hidden_states=store_all_hidden_states,
         )
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.esm]
 
     def forward(
         self,

--- a/fastplms/e1/README.md
+++ b/fastplms/e1/README.md
@@ -78,6 +78,24 @@ import torch
 model = AutoModelForMaskedLM.from_pretrained('Synthyra/Profluent-E1-150M', trust_remote_code=True, dtype=torch.float) # fp32
 ```
 
+## Experimental test-time training
+
+TTT is disabled by default. Normal E1 inference, MSA-context utilities,
+embeddings, and `state_dict()` keys are unchanged unless you explicitly call
+`model.ttt(...)`. The current implementation is experimental and trains only
+local LoRA adapters with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Embed entire datasets with no new code
 To embed a list of protein sequences **fast**, just call embed_dataset. Sequences are sorted to reduce padding tokens, so the initial progress bar estimation is usually much longer than the actual time it will take.
 

--- a/fastplms/e1/modeling_e1.py
+++ b/fastplms/e1/modeling_e1.py
@@ -43,6 +43,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -2773,7 +2774,7 @@ class E1Model(E1PreTrainedModel, EmbeddingMixin):
         )
 
 
-class E1ForMaskedLM(E1PreTrainedModel, EmbeddingMixin):
+class E1ForMaskedLM(FastPLMTestTimeTrainingMixin, E1PreTrainedModel, EmbeddingMixin):
     config: E1Config
     config_class = E1Config
     def __init__(self, config: E1Config, **kwargs):
@@ -2789,6 +2790,7 @@ class E1ForMaskedLM(E1PreTrainedModel, EmbeddingMixin):
         self.gradient_checkpointing = config.gradient_checkpointing
         self.prep_tokens = self.model.prep_tokens
         self.post_init()
+        self.init_ttt({"lora_target_replace_module": "Attention"})
 
     @property
     def device_mesh(self) -> torch.distributed.device_mesh.DeviceMesh:
@@ -2796,6 +2798,61 @@ class E1ForMaskedLM(E1PreTrainedModel, EmbeddingMixin):
 
     def _embed(self, sequences: List[str], return_attention_mask: bool = False, **kwargs) -> torch.Tensor:
         return self.model._embed(sequences, return_attention_mask=return_attention_mask, **kwargs)
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.model]
+
+    def _ttt_tokenize(
+        self,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        if input_ids is not None:
+            return {
+                "input_ids": input_ids,
+                "within_seq_position_ids": kwargs["within_seq_position_ids"],
+                "global_position_ids": kwargs["global_position_ids"],
+                "sequence_ids": kwargs["sequence_ids"],
+            }
+        assert seq is not None, "Pass either seq or E1 token tensors for TTT."
+        sequences = [seq] if isinstance(seq, str) else seq
+        batch = self.prep_tokens.get_batch_kwargs(sequences, device=torch.device("cpu"))
+        return {
+            "input_ids": batch["input_ids"],
+            "within_seq_position_ids": batch["within_seq_position_ids"],
+            "global_position_ids": batch["global_position_ids"],
+            "sequence_ids": batch["sequence_ids"],
+        }
+
+    def _ttt_mask_token(self) -> int:
+        return int(self.prep_tokens.mask_token_id)
+
+    def _ttt_padding_token(self) -> int:
+        return int(self.prep_tokens.pad_token_id)
+
+    def _ttt_replacement_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        amino_acids = "ACDEFGHIKLMNPQRSTVWY"
+        ids = [self.prep_tokens.vocab[aa] for aa in amino_acids]
+        return torch.tensor(ids, device=input_ids.device, dtype=input_ids.dtype)
+
+    def _ttt_non_special_mask(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return ~self.prep_tokens.get_boundary_token_mask(input_ids)
+
+    def _ttt_predict_logits(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs
+        assert isinstance(batch, dict), "E1 TTT expects a tensor dictionary."
+        output = self(
+            input_ids=batch["input_ids"],
+            within_seq_position_ids=batch["within_seq_position_ids"],
+            global_position_ids=batch["global_position_ids"],
+            sequence_ids=batch["sequence_ids"],
+        )
+        return output.logits
 
     def search_homologues(
         self,

--- a/fastplms/esm2/README.md
+++ b/fastplms/esm2/README.md
@@ -82,6 +82,24 @@ with torch.no_grad():
 print(logits.shape) # (2, 11, 33)
 ```
 
+### Experimental test-time training
+
+TTT is disabled by default. Normal inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the ESM2 backbone using masked language modeling on the test protein. It can
+help difficult proteins, but it adds test-time compute and can hurt already
+confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ### For working with attention maps
 ```python
 import torch

--- a/fastplms/esm2/README_650.md
+++ b/fastplms/esm2/README_650.md
@@ -50,6 +50,24 @@ with torch.no_grad():
 print(logits.shape) # (2, 11, 33)
 ```
 
+### Experimental test-time training
+
+TTT is disabled by default. Normal inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the ESM2 backbone using masked language modeling on the test protein. It can
+help difficult proteins, but it adds test-time compute and can hurt already
+confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ### For working with attention maps
 ```python
 import torch

--- a/fastplms/esm2/modeling_fastesm.py
+++ b/fastplms/esm2/modeling_fastesm.py
@@ -35,6 +35,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -614,13 +615,14 @@ class FastEsmModel(FastEsmPreTrainedModel, EmbeddingMixin):
         )
 
 
-class FastEsmForMaskedLM(FastEsmPreTrainedModel, EmbeddingMixin):
+class FastEsmForMaskedLM(FastPLMTestTimeTrainingMixin, FastEsmPreTrainedModel, EmbeddingMixin):
     def __init__(self, config, **kwargs):
         FastEsmPreTrainedModel.__init__(self, config, **kwargs)
         self.esm = FAST_ESM_ENCODER(config, add_pooling_layer=False)
         self.lm_head = EsmLMHead(config)
         self.loss_fct = nn.CrossEntropyLoss()
         self.post_init()
+        self.init_ttt({"lora_target_replace_module": "EsmAttention"})
 
     def get_input_embeddings(self):
         return self.esm.embeddings.word_embeddings
@@ -647,6 +649,9 @@ class FastEsmForMaskedLM(FastEsmPreTrainedModel, EmbeddingMixin):
 
     def predict_contacts(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         return self.esm.predict_contacts(input_ids, attention_mask=attention_mask)
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.esm]
 
     def forward(
         self,

--- a/fastplms/esm3/README.md
+++ b/fastplms/esm3/README.md
@@ -44,6 +44,23 @@ You can also call sequence inference directly:
 output = model.forward_sequence(["MKTAYIAKQRQISFVKSHFSRQDILDLWIYHTQGYFP"])
 ```
 
+## Experimental Test-Time Training
+
+TTT is disabled by default. No LoRA adapters are injected during normal
+`forward_sequence`, `forward`, or `embed_dataset` calls. Calling `model.ttt(...)`
+opts in to experimental masked-LM adaptation of the ESM3 sequence track through
+local LoRA weights. It can improve some difficult proteins, but it adds
+test-time compute and can degrade already confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MKTAYIAKQRQISFVKSHFSRQDILDLWIYHTQGYFP",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 Switch between SDPA and Flex Attention after loading:
 
 ```python

--- a/fastplms/esm3/modeling_esm3.py
+++ b/fastplms/esm3/modeling_esm3.py
@@ -41,6 +41,11 @@ except ImportError:
     create_block_mask = None
     flex_attention = None
 
+try:
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
+except ImportError:
+    pass  # Running as HF Hub composite; shared definitions are above
+
 
 ESM3_OPEN_SMALL = "esm3_sm_open_v1"
 ESM3_OPEN_SMALL_ALIASES = {
@@ -1462,7 +1467,7 @@ class FastESM3PreTrainedModel(PreTrainedModel):
         return model
 
 
-class FastESM3Model(FastESM3PreTrainedModel):
+class FastESM3Model(FastPLMTestTimeTrainingMixin, FastESM3PreTrainedModel):
     config_class = FastESM3Config
 
     def __init__(self, config: FastESM3Config, **kwargs):
@@ -1470,6 +1475,7 @@ class FastESM3Model(FastESM3PreTrainedModel):
         self.tokenizer = EsmSequenceTokenizer()
         self.esm3 = _build_official_esm3(config)
         self.__dict__["_official_sdk_model"] = None
+        self.init_ttt({"lora_target_replace_module": "MultiHeadAttention"})
 
     @property
     def device(self) -> torch.device:
@@ -1692,6 +1698,9 @@ class FastESM3Model(FastESM3PreTrainedModel):
 
     def batch_generate(self, inputs, configs):
         return self._get_official_sdk_model().batch_generate(inputs, configs)
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.esm3]
 
     def forward_and_sample(self, input, sampling_configuration):
         return self._get_official_sdk_model().forward_and_sample(

--- a/fastplms/esm_plusplus/README_6B.md
+++ b/fastplms/esm_plusplus/README_6B.md
@@ -75,6 +75,25 @@ print(output.last_hidden_state.shape)
 
 Pass `output_hidden_states=True` if you need all intermediate hidden states.
 
+## Experimental Test-Time Training
+
+TTT is disabled by default. Normal ESM++ inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the ESMC backbone with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions. The 6B checkpoint is large, so start with small
+`steps`, `ags`, and `batch_size` values.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 1, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Binder Design Regularizer
 
 The FastPLMs binder design tutorial uses `Synthyra/ESMplusplus_6B` as the

--- a/fastplms/esm_plusplus/README_large.md
+++ b/fastplms/esm_plusplus/README_large.md
@@ -99,6 +99,24 @@ import torch
 model = AutoModelForMaskedLM.from_pretrained('Synthyra/ESMplusplus_large', trust_remote_code=True, dtype=torch.float16) # or torch.bfloat16
 ```
 
+## Experimental test-time training
+
+TTT is disabled by default. Normal ESM++ inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the ESMC backbone with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Embed entire datasets with no new code
 To embed a list of protein sequences **fast**, just call embed_dataset. Sequences are sorted to reduce padding tokens, so the initial progress bar estimation is usually much longer than the actual time it will take.
 

--- a/fastplms/esm_plusplus/README_small.md
+++ b/fastplms/esm_plusplus/README_small.md
@@ -99,6 +99,24 @@ import torch
 model = AutoModelForMaskedLM.from_pretrained('Synthyra/ESMplusplus_small', trust_remote_code=True, dtype=torch.float16) # or torch.bfloat16
 ```
 
+## Experimental test-time training
+
+TTT is disabled by default. Normal ESM++ inference, embeddings, logits, and
+`state_dict()` keys are unchanged unless you explicitly call `model.ttt(...)`.
+The current implementation is experimental and trains only local LoRA adapters
+on the ESMC backbone with masked language modeling on the test protein. It can
+help some difficult proteins, but it adds test-time compute and can degrade
+already confident predictions.
+
+```python
+metrics = model.ttt(
+    seq="MSTNPKPQRKTKRNT",
+    ttt_config={"steps": 3, "ags": 1, "batch_size": 1},
+)
+model.ttt_reset()
+print(metrics["losses"])
+```
+
 ## Embed entire datasets with no new code
 To embed a list of protein sequences **fast**, just call embed_dataset. Sequences are sorted to reduce padding tokens, so the initial progress bar estimation is usually much longer than the actual time it will take.
 

--- a/fastplms/esm_plusplus/modeling_esm_plusplus.py
+++ b/fastplms/esm_plusplus/modeling_esm_plusplus.py
@@ -43,6 +43,7 @@ try:
         Pooler, EmbeddingMixin, ProteinDataset, parse_fasta, build_collator,
         select_hidden_state_embeddings,
     )
+    from fastplms.test_time_training import FastPLMTestTimeTrainingMixin
 except ImportError:
     pass  # Running as HF Hub composite; shared definitions are above
 
@@ -815,7 +816,7 @@ class ESMplusplusModel(PreTrainedESMplusplusModel, EmbeddingMixin):
             s_max=transformer_output.s_max,
         )
 
-class ESMplusplusForMaskedLM(PreTrainedESMplusplusModel, EmbeddingMixin):
+class ESMplusplusForMaskedLM(FastPLMTestTimeTrainingMixin, PreTrainedESMplusplusModel, EmbeddingMixin):
     """
     ESM++ model for masked language modeling.
     Implements the base ESM++ architecture with a masked language modeling head.
@@ -837,6 +838,7 @@ class ESMplusplusForMaskedLM(PreTrainedESMplusplusModel, EmbeddingMixin):
         self.ce_loss = nn.CrossEntropyLoss()
         self.tokenizer = EsmSequenceTokenizer()
         self.init_weights()
+        self.init_ttt({"lora_target_replace_module": "MultiHeadAttention"})
 
     def get_input_embeddings(self):
         return self.embed
@@ -871,6 +873,9 @@ class ESMplusplusForMaskedLM(PreTrainedESMplusplusModel, EmbeddingMixin):
             hidden_state_index=hidden_state_index,
             store_all_hidden_states=store_all_hidden_states,
         )
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.transformer]
 
     def forward(
         self,

--- a/fastplms/esmfold/README.md
+++ b/fastplms/esmfold/README.md
@@ -12,7 +12,7 @@ The GitHub with the implementation and requirements.txt can be found [here](http
 
 # FastESMFold
 
-FastESMFold is a self-contained, HuggingFace-compatible reimplementation of ESMFold with optional **Test-Time Training (TTT)** and multi-backend attention (SDPA, Flash, Flex).
+FastESMFold is a self-contained, HuggingFace-compatible reimplementation of ESMFold with optional experimental **Test-Time Training (TTT)** and multi-backend attention (SDPA, Flash, Flex).
 
 No dependency on `fair-esm`, `proteinttt`, or `openfold`. Just `transformers`, `torch`, and `einops`.
 
@@ -22,7 +22,16 @@ Protein language models like ESM2 are trained on millions of sequences, but at i
 
 **Test-Time Training (TTT)** adapts the model to each individual protein before predicting its structure. The idea is simple: before folding, we briefly train the ESM2 backbone on the input sequence using masked language modeling (the same objective it was pretrained with). This forces the model to "study" the specific sequence, strengthening its internal representation of that protein's structural features.
 
-The adaptation uses **LoRA** (Low-Rank Adaptation) for efficiency: only small adapter weights are trained (~4.4M parameters out of 3.5B), and the base model is restored after each prediction. This takes 20-45 seconds per sequence on an A10G GPU but can dramatically improve structure prediction quality, especially on difficult targets where standard ESMFold produces low-confidence predictions.
+TTT is disabled by default. Standard `fold_protein(...)`, `infer(...)`, and
+`state_dict()` behavior are unchanged unless you explicitly pass `ttt=True` or
+call `fold_protein_ttt(...)`.
+
+The adaptation uses **LoRA** (Low-Rank Adaptation) for efficiency: only small
+adapter weights are trained (~4.4M parameters out of 3.5B), and the base model
+is restored after each prediction. This takes 20-45 seconds per sequence on an
+A10G GPU. It can improve structure prediction quality on difficult targets
+where standard ESMFold produces low-confidence predictions, but it is
+experimental and can degrade predictions that already have high confidence.
 
 **When is TTT most useful?**
 - Sequences with low baseline pLDDT (< 0.5): TTT can improve pLDDT by 10-30+ points
@@ -36,7 +45,7 @@ The adaptation uses **LoRA** (Low-Rank Adaptation) for efficiency: only small ad
 ## Key Features
 
 - **Standard ESMFold**: Full ESMFold v1 structure prediction, loadable via `AutoModel`
-- **Optional TTT**: Enable test-time training for improved structure prediction on difficult sequences
+- **Optional experimental TTT**: Enable test-time training for difficult sequences with explicit `ttt=True`
 - **Best structure selection**: When TTT is enabled, folds after each step and returns the structure with the highest pLDDT
 - **FastESM2 attention**: SDPA/Flash/Flex backends for the 3B ESM2 backbone
 - **Self-contained LoRA**: lora_diffusion-compatible implementation (no peft dependency)
@@ -64,9 +73,12 @@ plddt = output["plddt"].mean().item()
 print(f"pLDDT: {plddt:.3f}")
 ```
 
-### Structure prediction with TTT
+### Structure prediction with experimental TTT
 
-TTT adapts the ESM2 backbone to a specific input sequence via masked language modeling before folding. This can dramatically improve pLDDT on difficult sequences (e.g., 0.38 to 0.72).
+TTT adapts the ESM2 backbone to a specific input sequence via masked language
+modeling before folding. It can improve pLDDT on difficult sequences, but it is
+experimental, adds test-time compute, and should not be assumed to improve every
+sequence.
 
 ```python
 # Configure TTT
@@ -74,8 +86,10 @@ model._ttt_cfg.steps = 10      # 10 optimizer steps (default)
 model._ttt_cfg.lora_rank = 8   # LoRA rank (default)
 model._ttt_cfg.lora_alpha = 32 # LoRA scale (default)
 
-# fold_protein() runs TTT, folds after each step, returns best structure
-result = model.fold_protein("MKTLLILAVVAAALA...")
+# ttt=True runs TTT, folds after each step, returns best structure
+result = model.fold_protein("MKTLLILAVVAAALA...", ttt=True)
+# Equivalent:
+# result = model.fold_protein_ttt("MKTLLILAVVAAALA...")
 print(f"pLDDT: {result['plddt']:.3f}")
 print(f"Best step: {result['best_step']} (0=baseline, 1-10=TTT steps)")
 print(f"Step pLDDTs: {[f'{p:.2f}' for p in result['step_plddts']]}")
@@ -87,34 +101,37 @@ with open("structure.pdb", "w") as f:
 
 ### Return values
 
-`fold_protein(sequence)` returns a dict:
+`fold_protein(sequence)` returns a dict. Without `ttt=True`, `step_plddts`
+contains only the baseline pLDDT and `best_step` is `0`.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `plddt` | float | Best mean pLDDT across all TTT steps |
-| `ptm` | float | Predicted TM-score from best step |
-| `pdb_string` | str | PDB format structure from best step |
-| `step_plddts` | list[float] | pLDDT at each step [baseline, s1, ..., s10] |
-| `best_step` | int | Which step produced the best structure (0=baseline) |
+| `plddt` | float | Mean pLDDT for the selected structure |
+| `ptm` | float | Predicted TM-score for the selected structure |
+| `pdb_string` | str | PDB format structure |
+| `step_plddts` | list[float] | Baseline pLDDT, plus per-step pLDDT when TTT is enabled |
+| `best_step` | int | Which step produced the selected structure (0=baseline) |
 
-### Disabling TTT
+### TTT default behavior
 
-To use FastESMFold as a standard ESMFold (no TTT), set `steps=0` or call `infer()` directly:
+TTT is disabled by default. Use FastESMFold as a standard ESMFold by calling
+`fold_protein(...)` or `infer(...)` without `ttt=True`:
 
 ```python
-# Option 1: Set TTT steps to 0
-config = AutoConfig.from_pretrained("Synthyra/FastESMFold", trust_remote_code=True)
-config.ttt_config = {"steps": 0}
-model = AutoModel.from_pretrained("Synthyra/FastESMFold", config=config, trust_remote_code=True)
-result = model.fold_protein("MKTLLILAVVAAALA...")  # No TTT, just baseline fold
+# Baseline fold, no TTT
+result = model.fold_protein("MKTLLILAVVAAALA...")
+print(result["best_step"])  # 0
 
-# Option 2: Call infer() directly (inherited from EsmForProteinFolding)
+# Raw ESMFold output
 with torch.no_grad():
     output = model.infer("MKTLLILAVVAAALA...")
 pdb_strings = model.output_to_pdb(output)
 ```
 
-## TTT Benchmark
+## Experimental TTT Benchmark
+
+This benchmark is provided as an example of where TTT can help. It is not a
+guarantee of improvement on every sequence.
 
 Tested on 10 difficult sequences on A10G GPU:
 
@@ -155,7 +172,7 @@ TTT parameters are set via `config.ttt_config` (a dict) or by modifying `model._
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `lr` | 4e-4 | Learning rate for SGD optimizer |
-| `steps` | 10 | Number of optimizer steps (0 to disable TTT) |
+| `steps` | 10 | Number of optimizer steps when TTT is explicitly enabled |
 | `ags` | 4 | Gradient accumulation steps per optimizer step |
 | `batch_size` | 4 | Batch size for masked language model training |
 | `mask_ratio` | 0.15 | Fraction of tokens to mask |

--- a/fastplms/esmfold/modeling_fast_esmfold.py
+++ b/fastplms/esmfold/modeling_fast_esmfold.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
-"""FastESMFold: Self-contained ESMFold with FastESM2 attention backends + built-in Test-Time Training.
+"""FastESMFold: self-contained ESMFold with FastESM2 attention and opt-in TTT.
 
 Usage:
     from transformers import AutoModel
     model = AutoModel.from_pretrained("Synthyra/FastESMFold", trust_remote_code=True).cuda()
 
-    # Basic folding
+    # Basic folding, no TTT
     result = model.fold_protein("MKTLLILAVVA...")
     print(result["plddt"], result["pdb_string"][:100])
 
-    # Folding with TTT (test-time training improves structure prediction)
+    # Experimental folding with TTT
     result = model.fold_protein("MKTLLILAVVA...", ttt=True)
 
-Dependencies: torch, transformers, einops, peft (for LoRA TTT only)
+Dependencies: torch, transformers, einops
 No dependency on: esm (fair-esm), proteinttt, openfold
 """
 import copy
@@ -515,11 +515,11 @@ class FastEsmFoldConfig(EsmConfig):
 # =============================================================================
 
 class FastEsmForProteinFolding(EsmForProteinFolding):
-    """ESMFold with FastESM2 attention backends + built-in Test-Time Training.
+    """ESMFold with FastESM2 attention backends and opt-in experimental TTT.
 
     Inherits all folding logic (trunk, structure module, output_to_pdb, infer)
     from transformers.EsmForProteinFolding. Replaces the ESM2 backbone with
-    FastESM2 for optimized attention and adds TTT for improved structure prediction.
+    FastESM2 for optimized attention and adds opt-in TTT for difficult targets.
 
     Key API:
         result = model.fold_protein("MKTL...", ttt=True)
@@ -906,8 +906,46 @@ class FastEsmForProteinFolding(EsmForProteinFolding):
         self,
         sequence: str,
         return_pdb_string: bool = True,
+        ttt: bool = False,
     ) -> Dict[str, Any]:
-        """Fold a protein sequence with test-time training.
+        """Fold a protein sequence.
+
+        Test-time training is disabled by default. Pass ``ttt=True`` or call
+        ``fold_protein_ttt`` to opt in to experimental TTT.
+
+        Args:
+            sequence: Protein sequence (single-letter amino acid codes)
+            return_pdb_string: If True, include PDB string in output
+            ttt: If True, run experimental LoRA TTT before returning the best fold
+
+        Returns:
+            Dict with keys:
+                - plddt: float, mean pLDDT
+                - ptm: float, predicted TM-score
+                - pdb_string: str (if return_pdb_string=True), PDB from best step
+                - step_plddts: list[float], baseline pLDDT when TTT is disabled
+                - best_step: int, 0 when TTT is disabled
+        """
+        if ttt:
+            return self.fold_protein_ttt(
+                sequence=sequence,
+                return_pdb_string=return_pdb_string,
+            )
+        result = self._fold_single(sequence, return_pdb_string=return_pdb_string)
+        return {
+            "plddt": result["plddt"],
+            "ptm": result["ptm"],
+            "pdb_string": result.get("pdb_string"),
+            "step_plddts": [result["plddt"]],
+            "best_step": 0,
+        }
+
+    def fold_protein_ttt(
+        self,
+        sequence: str,
+        return_pdb_string: bool = True,
+    ) -> Dict[str, Any]:
+        """Fold a protein sequence with experimental test-time training.
 
         Runs TTT (masked language model adaptation via LoRA) for the configured
         number of steps, folding after each optimizer step to track pLDDT. Returns

--- a/fastplms/esmfold2/README.md
+++ b/fastplms/esmfold2/README.md
@@ -50,6 +50,44 @@ print(float(result.plddt.mean()))
 print(float(result.ptm))
 ```
 
+## Experimental Test-Time Training
+
+TTT is disabled by default. Standard `fold_protein(...)`, `fold(...)`, raw tensor
+inference, and `state_dict()` keys are unchanged unless you explicitly pass
+`ttt=True` or call `fold_protein_ttt(...)`.
+
+The ESMFold2 TTT path is experimental and protein-only in v1. It trains local
+LoRA adapters only on `_esmc` with a masked language modeling objective. The
+folding trunk, confidence head, diffusion head, and structure input pipeline are
+frozen. TTT can improve difficult low-confidence folds, but it adds substantial
+test-time compute and can degrade already confident predictions.
+
+```python
+result = model.fold_protein(
+    "MSTNPKPQRKTKRNT",
+    num_loops=1,
+    num_sampling_steps=10,
+    num_diffusion_samples=1,
+    seed=0,
+    ttt=True,
+    ttt_config={
+        "steps": 1,
+        "ags": 1,
+        "batch_size": 1,
+        "lora_rank": 8,
+        "lora_alpha": 32.0,
+    },
+)
+
+print(result.ttt_metrics["losses"])
+print(result.ttt_metrics["step_plddts"])
+print(result.ttt_metrics["best_step"])
+```
+
+`load_esmc=True` is required for TTT because the ESMC MLM head is loaded lazily
+from `config.esmc_id`. If that pretrained MLM head cannot be loaded, TTT raises
+an assertion instead of silently using a random head.
+
 ## Save mmCIF or PDB
 
 ```python

--- a/fastplms/esmfold2/esmfold2_molecular_complex.py
+++ b/fastplms/esmfold2/esmfold2_molecular_complex.py
@@ -44,6 +44,7 @@ class MolecularComplexResult:
     residue_index: torch.Tensor | None = None
     entity_id: torch.Tensor | None = None
     sae_features: np.ndarray | None = None  # [L, n_features]
+    ttt_metrics: dict[str, Any] | None = None
 
 
 @dataclass

--- a/fastplms/esmfold2/modeling_esmfold2.py
+++ b/fastplms/esmfold2/modeling_esmfold2.py
@@ -36,6 +36,7 @@ except ImportError:
     TE_AVAILABLE = False
 
 from transformers.modeling_utils import PreTrainedModel
+from fastplms.test_time_training import FastPLMTestTimeTrainingMixin, TTTConfig
 from .configuration_esmc import ESMCConfig as _FastPLMSESMCConfig
 from .configuration_esmc_sae import ESMCSAEConfig as _FastPLMSESMCSAEConfig
 from .configuration_esmfold2 import ESMFold2Config
@@ -66,7 +67,16 @@ from .esmfold2_aligner import Aligner as _FastPLMSESMFold2Aligner
 from .esmfold2_atom_indexer import AtomIndexer as _FastPLMSESMFold2AtomIndexer
 from .esmfold2_conformers import load_ccd as _fastplms_esmfold2_load_ccd
 from .esmfold2_constants import ELEMENT_NUMBER_TO_SYMBOL as _FASTPLMS_ESMFOLD2_ELEMENT_NUMBER_TO_SYMBOL
-from .esmfold2_constants_esm3 import CHAIN_BREAK_STR as _FASTPLMS_ESMFOLD2_CHAIN_BREAK_STR
+from .esmfold2_constants_esm3 import (
+    CHAIN_BREAK_STR as _FASTPLMS_ESMFOLD2_CHAIN_BREAK_STR,
+    SEQUENCE_BOS_TOKEN,
+    SEQUENCE_EOS_TOKEN,
+    SEQUENCE_MASK_TOKEN,
+    SEQUENCE_PAD_TOKEN,
+    SEQUENCE_STANDARD_AA_MAX_TOKEN,
+    SEQUENCE_STANDARD_AA_MIN_TOKEN,
+    SEQUENCE_VOCAB,
+)
 from .esmfold2_input_builder import StructurePredictionInput as _FastPLMSESMFold2StructurePredictionInput
 from .esmfold2_metrics import compute_rmsd as _fastplms_esmfold2_compute_rmsd
 from .esmfold2_misc import slice_any_object as _fastplms_esmfold2_slice_any_object
@@ -522,7 +532,7 @@ def _lm_precision_context(fp8: bool):
             yield
 
 
-class ESMFold2Model(PreTrainedModel):
+class ESMFold2Model(FastPLMTestTimeTrainingMixin, PreTrainedModel):
     """ESMFold2 — all-atom structure prediction with an ESMC PLM backbone.
 
     This is the standard released ESMFold2 architecture (uses a linear-
@@ -569,6 +579,7 @@ class ESMFold2Model(PreTrainedModel):
         )
         self._esmc: nn.Module | None = None
         self._esmc_fp8: bool = False  # set by load_esmc(fp8=True)
+        self._ttt_lm_head: nn.Module | None = None
         self._esmfold2_input_builder: Any | None = None
 
         pf = config.folding_trunk
@@ -619,6 +630,7 @@ class ESMFold2Model(PreTrainedModel):
             )
 
         self.post_init()
+        self.init_ttt({"lora_target_replace_module": "MultiHeadAttention"})
 
     def load_esmc(self, esmc_model_path: str, precision: str = "bf16") -> None:
         """Load the ESMC LM.
@@ -660,6 +672,108 @@ class ESMFold2Model(PreTrainedModel):
             self._esmc_fp8 = False
 
         self._esmc = esmc
+        self._ttt_lm_head = None
+
+    def _ensure_ttt_lm_head(self) -> None:
+        assert self._esmc is not None, "ESMFold2 TTT requires load_esmc=True."
+        if self._ttt_lm_head is not None:
+            return
+        from .modeling_esmc import ESMCForMaskedLM
+
+        mlm, loading_info = ESMCForMaskedLM.from_pretrained(
+            self.config.esmc_id,
+            output_loading_info=True,
+        )
+        missing_head_keys = [
+            key for key in loading_info["missing_keys"] if key.startswith("lm_head")
+        ]
+        assert len(missing_head_keys) == 0, (
+            f"ESMFold2 TTT could not load a pretrained ESMC MLM head from "
+            f"{self.config.esmc_id}: missing {missing_head_keys}"
+        )
+        dtype = next(self._esmc.parameters()).dtype
+        mlm = mlm.to(device=self.device, dtype=dtype).eval()
+        self._ttt_lm_head = mlm.lm_head
+        self._ttt_lm_head.requires_grad_(False)
+        del mlm
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        assert self._esmc is not None, "ESMFold2 TTT requires load_esmc=True."
+        return [self._esmc]
+
+    def _ttt_tokenize(
+        self,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs
+        if input_ids is not None:
+            return input_ids
+        assert seq is not None, "Pass either seq or input_ids for ESMFold2 TTT."
+        sequences = [seq] if isinstance(seq, str) else seq
+        token_to_id = {token: idx for idx, token in enumerate(SEQUENCE_VOCAB)}
+        encoded = []
+        for sequence in sequences:
+            token_ids = [SEQUENCE_BOS_TOKEN]
+            for amino_acid in sequence:
+                token_ids.append(
+                    token_to_id[amino_acid if amino_acid in token_to_id else "X"]
+                )
+            token_ids.append(SEQUENCE_EOS_TOKEN)
+            encoded.append(token_ids)
+        max_len = max(len(token_ids) for token_ids in encoded)
+        input_tensor = torch.full(
+            (len(encoded), max_len),
+            SEQUENCE_PAD_TOKEN,
+            dtype=torch.long,
+        )
+        for row, token_ids in enumerate(encoded):
+            input_tensor[row, : len(token_ids)] = torch.tensor(
+                token_ids,
+                dtype=torch.long,
+            )
+        return input_tensor
+
+    def _ttt_mask_token(self) -> int:
+        return SEQUENCE_MASK_TOKEN
+
+    def _ttt_padding_token(self) -> int:
+        return SEQUENCE_PAD_TOKEN
+
+    def _ttt_replacement_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return torch.arange(
+            SEQUENCE_STANDARD_AA_MIN_TOKEN,
+            SEQUENCE_STANDARD_AA_MAX_TOKEN,
+            device=input_ids.device,
+            dtype=input_ids.dtype,
+        )
+
+    def _ttt_non_special_mask(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return (input_ids >= SEQUENCE_STANDARD_AA_MIN_TOKEN) & (
+            input_ids < SEQUENCE_STANDARD_AA_MAX_TOKEN
+        )
+
+    def _ttt_predict_logits(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        **kwargs,
+    ) -> torch.Tensor:
+        del kwargs
+        assert isinstance(batch, torch.Tensor), (
+            "ESMFold2 TTT expects input_ids tensors."
+        )
+        assert self._esmc is not None, "ESMFold2 TTT requires load_esmc=True."
+        self._ensure_ttt_lm_head()
+        assert self._ttt_lm_head is not None
+        attention_mask = batch.ne(SEQUENCE_PAD_TOKEN)
+        output = self._esmc(
+            input_ids=batch,
+            attention_mask=attention_mask,
+            return_dict=True,
+            compute_sae=False,
+        )
+        return self._ttt_lm_head(output.last_hidden_state)
 
     @classmethod
     def from_pretrained(
@@ -1123,7 +1237,7 @@ class ESMFold2Model(PreTrainedModel):
             complex_id=complex_id,
         )
 
-    def fold_protein(
+    def _fold_protein_no_ttt(
         self,
         sequence: str,
         *,
@@ -1147,6 +1261,137 @@ class ESMFold2Model(PreTrainedModel):
             seed=seed,
             complex_id=complex_id,
         )
+
+    @staticmethod
+    def _ttt_mean_plddt(result) -> float:
+        assert result.plddt is not None, "ESMFold2 result has no pLDDT tensor."
+        return float(result.plddt.float().mean().item())
+
+    def _ttt_select_result(self, result):
+        if isinstance(result, list):
+            assert len(result) > 0, "ESMFold2 fold returned an empty result list."
+            return max(result, key=self._ttt_mean_plddt)
+        return result
+
+    def _ttt_eval_step(
+        self,
+        step: int,
+        loss: float,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs,
+    ) -> tuple[dict[str, Any], float | None]:
+        del input_ids
+        assert isinstance(seq, str), (
+            "ESMFold2 fold TTT is protein-only and sequence-string only."
+        )
+        fold_kwargs = kwargs["fold_kwargs"]
+        was_training = self.training
+        self.eval()
+        try:
+            result = self._fold_protein_no_ttt(seq, **fold_kwargs)
+        finally:
+            self.train(was_training)
+        selected = self._ttt_select_result(result)
+        plddt = self._ttt_mean_plddt(selected)
+        return {
+            "step": step,
+            "loss": loss,
+            "plddt": plddt,
+            "result": selected,
+        }, plddt
+
+    def fold_protein(
+        self,
+        sequence: str,
+        *,
+        chain_id: str = "A",
+        num_loops: int = 3,
+        num_sampling_steps: int = 50,
+        num_diffusion_samples: int = 1,
+        seed: int | None = None,
+        complex_id: str = "pred",
+        ttt: bool = False,
+        ttt_config: TTTConfig | dict[str, Any] | None = None,
+    ):
+        if ttt:
+            return self.fold_protein_ttt(
+                sequence=sequence,
+                chain_id=chain_id,
+                num_loops=num_loops,
+                num_sampling_steps=num_sampling_steps,
+                num_diffusion_samples=num_diffusion_samples,
+                seed=seed,
+                complex_id=complex_id,
+                ttt_config=ttt_config,
+            )
+        return self._fold_protein_no_ttt(
+            sequence=sequence,
+            chain_id=chain_id,
+            num_loops=num_loops,
+            num_sampling_steps=num_sampling_steps,
+            num_diffusion_samples=num_diffusion_samples,
+            seed=seed,
+            complex_id=complex_id,
+        )
+
+    def fold_protein_ttt(
+        self,
+        sequence: str,
+        *,
+        chain_id: str = "A",
+        num_loops: int = 3,
+        num_sampling_steps: int = 50,
+        num_diffusion_samples: int = 1,
+        seed: int | None = None,
+        complex_id: str = "pred",
+        ttt_config: TTTConfig | dict[str, Any] | None = None,
+    ):
+        assert self._esmc is not None, "ESMFold2 TTT requires load_esmc=True."
+        fold_kwargs = {
+            "chain_id": chain_id,
+            "num_loops": num_loops,
+            "num_sampling_steps": num_sampling_steps,
+            "num_diffusion_samples": num_diffusion_samples,
+            "seed": seed,
+            "complex_id": complex_id,
+        }
+        baseline = self._ttt_select_result(
+            self._fold_protein_no_ttt(sequence, **fold_kwargs)
+        )
+        baseline_plddt = self._ttt_mean_plddt(baseline)
+        best_result = baseline
+        best_plddt = baseline_plddt
+        best_step = 0
+        step_plddts = [baseline_plddt]
+
+        cfg = self.ttt_config.merged(ttt_config).merged(
+            {"eval_each_step": True, "automatic_best_state_reset": False}
+        )
+        try:
+            metrics = self.ttt(
+                seq=sequence,
+                ttt_config=cfg,
+                fold_kwargs=fold_kwargs,
+            )
+            for step_metric in metrics["step_metrics"]:
+                step_plddt = step_metric["plddt"]
+                step_plddts.append(step_plddt)
+                if step_plddt > best_plddt:
+                    best_plddt = step_plddt
+                    best_step = step_metric["step"]
+                    best_result = step_metric["result"]
+            best_result.ttt_metrics = {
+                "losses": metrics["losses"],
+                "step_plddts": step_plddts,
+                "baseline_plddt": baseline_plddt,
+                "best_plddt": best_plddt,
+                "best_step": best_step,
+            }
+            return best_result
+        finally:
+            if "_ttt_initialized" in self.__dict__ and self._ttt_initialized:
+                self.ttt_reset()
 
     @staticmethod
     def result_to_cif(result) -> str:

--- a/fastplms/test_time_training.py
+++ b/fastplms/test_time_training.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import typing as T
+from dataclasses import dataclass, fields
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class TTTConfig:
+    lr: float = 4e-4
+    steps: int = 30
+    ags: int = 16
+    batch_size: int = 2
+    mask_ratio: float = 0.15
+    crop_size: int = 1024
+    bert_leave_prob: float = 0.1
+    bert_replace_prob: float = 0.1
+    optimizer: str = "sgd"
+    momentum: float = 0.0
+    weight_decay: float = 0.0
+    seed: int | None = 0
+    lora_rank: int = 8
+    lora_alpha: float = 32.0
+    lora_target_replace_module: str | None = None
+    lora_target_modules: tuple[str, ...] | None = None
+    initial_state_reset: bool = True
+    automatic_best_state_reset: bool = False
+    eval_each_step: bool = False
+    gradient_clip: bool = False
+    gradient_clip_max_norm: float = 1.0
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: T.Any) -> "TTTConfig":
+        valid_names = {field.name for field in fields(cls)}
+        unknown_names = set(kwargs) - valid_names
+        assert len(unknown_names) == 0, f"Unknown TTTConfig fields: {sorted(unknown_names)}"
+        return cls(**kwargs)
+
+    def merged(self, overrides: T.Mapping[str, T.Any] | "TTTConfig" | None) -> "TTTConfig":
+        if overrides is None:
+            return self
+        if isinstance(overrides, TTTConfig):
+            return overrides
+        values = {field.name: self.__dict__[field.name] for field in fields(self)}
+        for name, value in overrides.items():
+            assert name in values, f"Unknown TTTConfig field: {name}"
+            values[name] = value
+        return TTTConfig(**values)
+
+    def verify(self) -> None:
+        assert self.lr > 0.0, "TTT learning rate must be positive."
+        assert self.steps >= 1, "TTT steps must be >= 1."
+        assert self.ags >= 1, "TTT gradient accumulation steps must be >= 1."
+        assert self.batch_size >= 1, "TTT batch_size must be >= 1."
+        assert 0.0 < self.mask_ratio <= 1.0, "TTT mask_ratio must be in (0, 1]."
+        assert self.crop_size >= 1, "TTT crop_size must be >= 1."
+        assert self.lora_rank >= 1, "TTT v1 is LoRA-only, so lora_rank must be >= 1."
+        assert self.lora_alpha > 0.0, "TTT lora_alpha must be positive."
+        assert self.optimizer in {"adamw", "sgd"}, "TTT optimizer must be 'adamw' or 'sgd'."
+        assert 0.0 <= self.bert_leave_prob <= 1.0, "bert_leave_prob must be in [0, 1]."
+        assert 0.0 <= self.bert_replace_prob <= 1.0, "bert_replace_prob must be in [0, 1]."
+        assert self.bert_leave_prob + self.bert_replace_prob <= 1.0, (
+            "bert_leave_prob + bert_replace_prob must be <= 1."
+        )
+        if self.gradient_clip:
+            assert self.gradient_clip_max_norm > 0.0, "gradient_clip_max_norm must be positive."
+
+
+class LoraInjectedLinear(nn.Module):
+    def __init__(self, linear: nn.Module, rank: int, alpha: float) -> None:
+        super().__init__()
+        weight = linear._parameters["weight"]
+        assert weight.ndim == 2, "LoRA can only wrap 2D linear weights."
+        self.linear = linear
+        self.linear.requires_grad_(False)
+        self.rank = rank
+        self.scale = alpha
+        in_features = weight.shape[1]
+        out_features = weight.shape[0]
+        self.lora_down = nn.Linear(in_features, rank, bias=False, dtype=torch.float32)
+        self.lora_up = nn.Linear(rank, out_features, bias=False, dtype=torch.float32)
+        self.lora_down.to(device=weight.device)
+        self.lora_up.to(device=weight.device)
+        nn.init.normal_(self.lora_down.weight, std=1.0 / rank)
+        nn.init.zeros_(self.lora_up.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        base = self.linear(x)
+        delta = self.lora_up(self.lora_down(x.to(dtype=torch.float32))) * self.scale
+        return base + delta.to(dtype=base.dtype)
+
+
+class FastPLMTestTimeTrainingMixin:
+    def init_ttt(self, ttt_config: TTTConfig | T.Mapping[str, T.Any] | None = None) -> None:
+        base_config = TTTConfig()
+        self._ttt_cfg = base_config.merged(ttt_config)
+        self._ttt_cfg.verify()
+        self._ttt_initialized = False
+        self._ttt_initial_state: list[dict[str, torch.Tensor]] | None = None
+
+    @property
+    def ttt_config(self) -> TTTConfig:
+        if "_ttt_cfg" not in self.__dict__:
+            self.init_ttt()
+        return self._ttt_cfg
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self]
+
+    def _ttt_get_frozen_modules(self) -> list[nn.Module]:
+        return []
+
+    def _ttt_tokenize(
+        self,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs: T.Any,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        del kwargs
+        if input_ids is not None:
+            return input_ids
+        assert seq is not None, "Pass either seq or input_ids for TTT."
+        tokenized = self.tokenizer(seq, return_tensors="pt", padding=True)
+        return tokenized["input_ids"]
+
+    def _ttt_mask_token(self) -> int:
+        return int(self.tokenizer.mask_token_id)
+
+    def _ttt_padding_token(self) -> int:
+        return int(self.tokenizer.pad_token_id)
+
+    def _ttt_replacement_tokens(self, input_ids: torch.Tensor) -> torch.Tensor:
+        tokenizer = self.tokenizer
+        special_ids = set(tokenizer.all_special_ids)
+        vocab_size = int(self.config.vocab_size)
+        ids = [idx for idx in range(vocab_size) if idx not in special_ids]
+        assert len(ids) > 0, "TTT replacement token set is empty."
+        return torch.tensor(ids, device=input_ids.device, dtype=input_ids.dtype)
+
+    def _ttt_predict_logits(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        **kwargs: T.Any,
+    ) -> torch.Tensor:
+        del kwargs
+        if isinstance(batch, dict):
+            output = self(**batch)
+            return output.logits
+        attention_mask = batch.ne(self._ttt_padding_token())
+        output = self(input_ids=batch, attention_mask=attention_mask)
+        return output.logits
+
+    def _ttt_eval_step(
+        self,
+        step: int,
+        loss: float,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        **kwargs: T.Any,
+    ) -> tuple[dict[str, T.Any], float | None]:
+        del step, loss, seq, input_ids, kwargs
+        return {}, None
+
+    def _ttt_is_lora_target(
+        self,
+        name: str,
+        full_name: str,
+        module: nn.Module,
+        active: bool,
+        target_modules: tuple[str, ...] | None,
+    ) -> bool:
+        if not active:
+            return False
+        if isinstance(module, LoraInjectedLinear):
+            return False
+        if (
+            target_modules is not None
+            and name not in target_modules
+            and full_name not in target_modules
+        ):
+            return False
+        if isinstance(module, nn.Linear):
+            return True
+        if "weight" not in module._parameters:
+            return False
+        weight = module._parameters["weight"]
+        if weight is None or weight.ndim != 2:
+            return False
+        return "Linear" in module.__class__.__name__
+
+    def _ttt_inject_lora(self) -> int:
+        cfg = self.ttt_config
+        cfg.verify()
+        target_class = cfg.lora_target_replace_module
+        target_modules = cfg.lora_target_modules
+        wrapped = 0
+
+        def inject(module: nn.Module, prefix: str, active: bool) -> None:
+            nonlocal wrapped
+            for name, child in list(module.named_children()):
+                full_name = f"{prefix}.{name}" if prefix else name
+                child_active = active
+                if target_class is not None:
+                    child_active = active or child.__class__.__name__ == target_class
+                if self._ttt_is_lora_target(name, full_name, child, child_active, target_modules):
+                    setattr(
+                        module,
+                        name,
+                        LoraInjectedLinear(child, rank=cfg.lora_rank, alpha=cfg.lora_alpha),
+                    )
+                    wrapped += 1
+                    continue
+                inject(child, full_name, child_active)
+
+        for trainable_module in self._ttt_get_trainable_modules():
+            inject(trainable_module, "", target_class is None)
+        assert wrapped > 0, "TTT LoRA injection did not find any target modules."
+        return wrapped
+
+    def _ttt_lora_modules(self) -> list[LoraInjectedLinear]:
+        return [module for module in self.modules() if isinstance(module, LoraInjectedLinear)]
+
+    def _ttt_lora_parameters(self) -> list[nn.Parameter]:
+        params: list[nn.Parameter] = []
+        for module in self._ttt_lora_modules():
+            params.extend(module.lora_down.parameters())
+            params.extend(module.lora_up.parameters())
+        assert len(params) > 0, "TTT has no LoRA parameters."
+        return params
+
+    def _ttt_snapshot_lora_state(self) -> list[dict[str, torch.Tensor]]:
+        snapshot = []
+        for module in self._ttt_lora_modules():
+            snapshot.append(
+                {
+                    "lora_down.weight": module.lora_down.weight.detach().clone(),
+                    "lora_up.weight": module.lora_up.weight.detach().clone(),
+                }
+            )
+        assert len(snapshot) > 0, "TTT has no LoRA state to snapshot."
+        return snapshot
+
+    def _ttt_restore_lora_state(self, state: list[dict[str, torch.Tensor]]) -> None:
+        modules = self._ttt_lora_modules()
+        assert len(modules) == len(state), "TTT LoRA state/module count mismatch."
+        with torch.no_grad():
+            for module, module_state in zip(modules, state):
+                module.lora_down.weight.copy_(module_state["lora_down.weight"])
+                module.lora_up.weight.copy_(module_state["lora_up.weight"])
+
+    def _ttt_ensure_initialized(self) -> None:
+        if "_ttt_cfg" not in self.__dict__:
+            self.init_ttt()
+        if self._ttt_initialized:
+            return
+        self._ttt_inject_lora()
+        self._ttt_initial_state = self._ttt_snapshot_lora_state()
+        self._ttt_initialized = True
+
+    def ttt_reset(self) -> None:
+        self._ttt_ensure_initialized()
+        assert self._ttt_initial_state is not None, "TTT initial state is not available."
+        self._ttt_restore_lora_state(self._ttt_initial_state)
+
+    def _ttt_make_optimizer(self) -> torch.optim.Optimizer:
+        cfg = self.ttt_config
+        params = self._ttt_lora_parameters()
+        if cfg.optimizer == "sgd":
+            return torch.optim.SGD(
+                params,
+                lr=cfg.lr,
+                momentum=cfg.momentum,
+                weight_decay=cfg.weight_decay,
+            )
+        return torch.optim.AdamW(params, lr=cfg.lr, weight_decay=cfg.weight_decay)
+
+    def _ttt_to_device(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        device: torch.device,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        if isinstance(batch, dict):
+            return {name: tensor.to(device) for name, tensor in batch.items()}
+        return batch.to(device)
+
+    def _ttt_input_ids_from_batch(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        if isinstance(batch, dict):
+            return batch["input_ids"]
+        return batch
+
+    def _ttt_set_input_ids(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        if isinstance(batch, dict):
+            updated = dict(batch)
+            updated["input_ids"] = input_ids
+            return updated
+        return input_ids
+
+    def _ttt_non_special_mask(self, input_ids: torch.Tensor) -> torch.Tensor:
+        pad_token = self._ttt_padding_token()
+        mask = input_ids.ne(pad_token)
+        special_ids = set(self.tokenizer.all_special_ids)
+        for special_id in special_ids:
+            mask = mask & input_ids.ne(int(special_id))
+        return mask
+
+    def _ttt_sample_crop(
+        self,
+        batch: torch.Tensor | dict[str, torch.Tensor],
+        generator: torch.Generator,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        input_ids = self._ttt_input_ids_from_batch(batch)
+        cfg = self.ttt_config
+        if input_ids.shape[1] <= cfg.crop_size:
+            return batch
+        high = input_ids.shape[1] - cfg.crop_size + 1
+        start = int(
+            torch.randint(
+                high,
+                (1,),
+                generator=generator,
+                device=input_ids.device,
+            ).item()
+        )
+        end = start + cfg.crop_size
+        if isinstance(batch, dict):
+            cropped = {}
+            for name, tensor in batch.items():
+                if tensor.ndim >= 2 and tensor.shape[1] == input_ids.shape[1]:
+                    cropped[name] = tensor[:, start:end]
+                else:
+                    cropped[name] = tensor
+            return cropped
+        return input_ids[:, start:end]
+
+    def _ttt_sample_batch(
+        self,
+        tokenized: torch.Tensor | dict[str, torch.Tensor],
+        generator: torch.Generator,
+    ) -> tuple[torch.Tensor | dict[str, torch.Tensor], torch.Tensor]:
+        cfg = self.ttt_config
+        batch = self._ttt_sample_crop(tokenized, generator)
+        input_ids = self._ttt_input_ids_from_batch(batch)
+        rows = torch.randint(
+            input_ids.shape[0],
+            (cfg.batch_size,),
+            generator=generator,
+            device=input_ids.device,
+        )
+        if isinstance(batch, dict):
+            sampled: torch.Tensor | dict[str, torch.Tensor] = {}
+            for name, tensor in batch.items():
+                if tensor.ndim >= 1 and tensor.shape[0] == input_ids.shape[0]:
+                    sampled[name] = tensor.index_select(0, rows)
+                else:
+                    sampled[name] = tensor
+        else:
+            sampled = input_ids.index_select(0, rows)
+
+        sampled_ids = self._ttt_input_ids_from_batch(sampled)
+        labels = sampled_ids.clone()
+        non_special = self._ttt_non_special_mask(sampled_ids)
+        label_mask = torch.zeros_like(non_special)
+        for row_idx in range(sampled_ids.shape[0]):
+            candidate_positions = torch.where(non_special[row_idx])[0]
+            if candidate_positions.numel() == 0:
+                continue
+            num_mask = max(1, int(round(candidate_positions.numel() * cfg.mask_ratio)))
+            order = torch.randperm(
+                candidate_positions.numel(),
+                generator=generator,
+                device=sampled_ids.device,
+            )
+            chosen = candidate_positions[order[:num_mask]]
+            label_mask[row_idx, chosen] = True
+        labels = labels.masked_fill(~label_mask, -100)
+
+        masked_ids = sampled_ids.clone()
+        chosen_positions = torch.where(label_mask)
+        if chosen_positions[0].numel() > 0:
+            random_values = torch.rand(
+                chosen_positions[0].shape,
+                generator=generator,
+                device=sampled_ids.device,
+            )
+            leave = random_values < cfg.bert_leave_prob
+            replace = (random_values >= cfg.bert_leave_prob) & (
+                random_values < cfg.bert_leave_prob + cfg.bert_replace_prob
+            )
+            mask = ~(leave | replace)
+            if mask.any():
+                masked_ids[
+                    chosen_positions[0][mask],
+                    chosen_positions[1][mask],
+                ] = self._ttt_mask_token()
+            if replace.any():
+                replacement_tokens = self._ttt_replacement_tokens(sampled_ids)
+                replacement_idx = torch.randint(
+                    replacement_tokens.shape[0],
+                    (int(replace.sum().item()),),
+                    generator=generator,
+                    device=sampled_ids.device,
+                )
+                masked_ids[
+                    chosen_positions[0][replace],
+                    chosen_positions[1][replace],
+                ] = replacement_tokens[replacement_idx]
+
+        return self._ttt_set_input_ids(sampled, masked_ids), labels
+
+    def ttt(
+        self,
+        seq: str | list[str] | None = None,
+        input_ids: torch.Tensor | None = None,
+        ttt_config: TTTConfig | T.Mapping[str, T.Any] | None = None,
+        **kwargs: T.Any,
+    ) -> dict[str, T.Any]:
+        if ttt_config is not None:
+            if "_ttt_initialized" in self.__dict__ and self._ttt_initialized:
+                next_cfg = self.ttt_config.merged(ttt_config)
+                assert next_cfg.lora_rank == self.ttt_config.lora_rank, (
+                    "Changing lora_rank after TTT initialization is not supported."
+                )
+                assert next_cfg.lora_alpha == self.ttt_config.lora_alpha, (
+                    "Changing lora_alpha after TTT initialization is not supported."
+                )
+                assert (
+                    next_cfg.lora_target_replace_module
+                    == self.ttt_config.lora_target_replace_module
+                ), "Changing LoRA target class after TTT initialization is not supported."
+                assert next_cfg.lora_target_modules == self.ttt_config.lora_target_modules, (
+                    "Changing LoRA target modules after TTT initialization is not supported."
+                )
+                self._ttt_cfg = next_cfg
+            else:
+                self.init_ttt(ttt_config)
+
+        self._ttt_ensure_initialized()
+        cfg = self.ttt_config
+        if cfg.initial_state_reset:
+            self.ttt_reset()
+
+        device = next(self.parameters()).device
+        tokenized = self._ttt_tokenize(seq=seq, input_ids=input_ids, **kwargs)
+        tokenized = self._ttt_to_device(tokenized, device)
+        generator_device = device if device.type == "cuda" else torch.device("cpu")
+        generator = torch.Generator(device=generator_device)
+        if cfg.seed is not None:
+            generator.manual_seed(cfg.seed)
+
+        module_modes = {module: module.training for module in self.modules()}
+        requires_grad = {param: param.requires_grad for param in self.parameters()}
+        losses: list[float] = []
+        step_metrics: list[dict[str, T.Any]] = []
+        best_state: list[dict[str, torch.Tensor]] | None = None
+        best_metric: float | None = None
+        best_step = 0
+
+        try:
+            self.train()
+            for param in self.parameters():
+                param.requires_grad_(False)
+            for param in self._ttt_lora_parameters():
+                param.requires_grad_(True)
+
+            optimizer = self._ttt_make_optimizer()
+            optimizer.zero_grad(set_to_none=True)
+            total_micro_steps = cfg.steps * cfg.ags
+            for micro_step in range(total_micro_steps):
+                batch, labels = self._ttt_sample_batch(tokenized, generator)
+                logits = self._ttt_predict_logits(batch, **kwargs)
+                labels = labels.to(device=logits.device)
+                loss = F.cross_entropy(
+                    logits.reshape(-1, logits.shape[-1]),
+                    labels.reshape(-1),
+                    ignore_index=-100,
+                )
+                (loss / cfg.ags).backward()
+                if (micro_step + 1) % cfg.ags != 0:
+                    continue
+
+                if cfg.gradient_clip:
+                    torch.nn.utils.clip_grad_norm_(
+                        self._ttt_lora_parameters(),
+                        cfg.gradient_clip_max_norm,
+                    )
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+                step = (micro_step + 1) // cfg.ags
+                loss_value = float(loss.detach().item())
+                losses.append(loss_value)
+                if cfg.eval_each_step:
+                    metrics, metric = self._ttt_eval_step(
+                        step=step,
+                        loss=loss_value,
+                        seq=seq,
+                        input_ids=input_ids,
+                        **kwargs,
+                    )
+                    if len(metrics) > 0:
+                        step_metrics.append(metrics)
+                    if metric is not None and (
+                        best_metric is None or metric > best_metric
+                    ):
+                        best_metric = metric
+                        best_step = step
+                        best_state = self._ttt_snapshot_lora_state()
+
+            if cfg.automatic_best_state_reset and best_state is not None:
+                self._ttt_restore_lora_state(best_state)
+        finally:
+            for param, value in requires_grad.items():
+                param.requires_grad_(value)
+            for module, training in module_modes.items():
+                module.train(training)
+
+        return {
+            "losses": losses,
+            "step_metrics": step_metrics,
+            "best_step": best_step,
+            "best_metric": best_metric,
+        }

--- a/fastplms/test_time_training.py
+++ b/fastplms/test_time_training.py
@@ -87,6 +87,14 @@ class LoraInjectedLinear(nn.Module):
         nn.init.normal_(self.lora_down.weight, std=1.0 / rank)
         nn.init.zeros_(self.lora_up.weight)
 
+    @property
+    def weight(self) -> torch.Tensor:
+        return self.linear._parameters["weight"]
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        return self.linear._parameters["bias"]
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         base = self.linear(x)
         delta = self.lora_up(self.lora_down(x.to(dtype=torch.float32))) * self.scale

--- a/testing/test_ttt.py
+++ b/testing/test_ttt.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+
+from fastplms.ankh.modeling_ankh import FastAnkhForMaskedLM
+from fastplms.dplm.modeling_dplm import DPLMForMaskedLM
+from fastplms.dplm2.modeling_dplm2 import DPLM2ForMaskedLM
+from fastplms.e1.modeling_e1 import E1ForMaskedLM
+from fastplms.esm2.modeling_fastesm import FastEsmForMaskedLM
+from fastplms.esm3.modeling_esm3 import FastESM3Model
+from fastplms.esm_plusplus.modeling_esm_plusplus import ESMplusplusForMaskedLM
+from fastplms.esmfold2.modeling_esmfold2 import ESMFold2Model
+from fastplms.test_time_training import (
+    FastPLMTestTimeTrainingMixin,
+    LoraInjectedLinear,
+)
+from testing.conftest import MODEL_REGISTRY, STRUCTURE_MODEL_REGISTRY
+
+
+TEST_SEQUENCE = "MSTNPKPQRKTKRNT"
+LOCAL_MODEL_CLASSES = {
+    "esm2": FastEsmForMaskedLM,
+    "esmc": ESMplusplusForMaskedLM,
+    "esm3": FastESM3Model,
+    "e1": E1ForMaskedLM,
+    "dplm": DPLMForMaskedLM,
+    "dplm2": DPLM2ForMaskedLM,
+    "ankh": FastAnkhForMaskedLM,
+}
+
+
+class DummyConfig:
+    vocab_size = 8
+
+
+class DummyTokenizer:
+    pad_token_id = 0
+    cls_token_id = 1
+    eos_token_id = 2
+    mask_token_id = 3
+    all_special_ids = [0, 1, 2, 3]
+
+    def __init__(self) -> None:
+        self.vocab = {
+            "A": 4,
+            "C": 5,
+            "D": 6,
+            "E": 7,
+        }
+
+    def __call__(
+        self,
+        seq: str | list[str],
+        return_tensors: str = "pt",
+        padding: bool = True,
+    ) -> dict[str, torch.Tensor]:
+        del return_tensors, padding
+        sequences = [seq] if isinstance(seq, str) else seq
+        encoded = []
+        for sequence in sequences:
+            encoded.append(
+                [self.cls_token_id]
+                + [self.vocab[aa] for aa in sequence]
+                + [self.eos_token_id]
+            )
+        max_len = max(len(ids) for ids in encoded)
+        input_ids = torch.full((len(encoded), max_len), self.pad_token_id)
+        for row, ids in enumerate(encoded):
+            input_ids[row, : len(ids)] = torch.tensor(ids)
+        return {"input_ids": input_ids.long()}
+
+
+class DummyTTTModel(FastPLMTestTimeTrainingMixin, nn.Module):
+    def __init__(self) -> None:
+        nn.Module.__init__(self)
+        self.config = DummyConfig()
+        self.tokenizer = DummyTokenizer()
+        self.embed = nn.Embedding(self.config.vocab_size, 8)
+        self.backbone = nn.Sequential(
+            nn.Linear(8, 8),
+            nn.GELU(),
+            nn.Linear(8, 8),
+        )
+        self.lm_head = nn.Linear(8, self.config.vocab_size)
+        self.init_ttt(
+            {
+                "steps": 1,
+                "ags": 1,
+                "batch_size": 1,
+                "mask_ratio": 1.0,
+                "bert_leave_prob": 0.0,
+                "bert_replace_prob": 0.0,
+                "lora_rank": 2,
+                "lora_alpha": 1.0,
+            }
+        )
+
+    def _ttt_get_trainable_modules(self) -> list[nn.Module]:
+        return [self.backbone]
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+    ):
+        del attention_mask
+        hidden = self.backbone(self.embed(input_ids))
+        return SimpleNamespace(logits=self.lm_head(hidden))
+
+
+def test_ttt_masking_masks_only_residue_tokens() -> None:
+    model = DummyTTTModel()
+    tokenized = model._ttt_tokenize(seq="ACDE")
+    generator = torch.Generator()
+    generator.manual_seed(0)
+
+    batch, labels = model._ttt_sample_batch(tokenized, generator)
+
+    assert isinstance(batch, torch.Tensor)
+    assert labels[0, 0].item() == -100
+    assert labels[0, -1].item() == -100
+    assert torch.all(batch[labels != -100] == model.tokenizer.mask_token_id)
+
+
+def test_ttt_lora_injection_is_lazy_and_backbone_scoped() -> None:
+    model = DummyTTTModel()
+
+    assert all("lora_" not in name for name in model.state_dict())
+
+    model._ttt_ensure_initialized()
+
+    assert any(isinstance(module, LoraInjectedLinear) for module in model.backbone.modules())
+    assert not any(isinstance(module, LoraInjectedLinear) for module in model.lm_head.modules())
+
+
+def test_ttt_only_lora_params_change_and_reset_restores_adapter() -> None:
+    model = DummyTTTModel()
+    model._ttt_ensure_initialized()
+    initial = {
+        name: parameter.detach().clone()
+        for name, parameter in model.named_parameters()
+    }
+
+    metrics = model.ttt(seq="ACDE")
+
+    changed = [
+        name
+        for name, parameter in model.named_parameters()
+        if not torch.equal(parameter.detach(), initial[name])
+    ]
+    assert len(metrics["losses"]) == 1
+    assert len(changed) > 0
+    assert all("lora_" in name for name in changed)
+
+    model.ttt_reset()
+    for name, parameter in model.named_parameters():
+        torch.testing.assert_close(parameter.detach(), initial[name])
+
+
+@pytest.mark.gpu
+@pytest.mark.parametrize("model_key", list(MODEL_REGISTRY))
+def test_sequence_model_ttt_smoke(model_key: str) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for FastPLMs model smoke tests.")
+    config = MODEL_REGISTRY[model_key]
+    model_cls = LOCAL_MODEL_CLASSES[model_key]
+    model = (
+        model_cls.from_pretrained(
+            config["fast_path"],
+            dtype=torch.float32,
+        )
+        .eval()
+        .cuda()
+    )
+    metrics = model.ttt(
+        seq=TEST_SEQUENCE,
+        ttt_config={
+            "steps": 1,
+            "ags": 1,
+            "batch_size": 1,
+            "crop_size": 64,
+            "lora_rank": 2,
+            "lora_alpha": 1.0,
+        },
+    )
+
+    assert len(metrics["losses"]) == 1
+    assert callable(model.ttt_reset)
+    model.ttt_reset()
+    del model
+    torch.cuda.empty_cache()
+
+
+@pytest.mark.structure
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_esmfold2_ttt_smoke() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for ESMFold2 TTT smoke tests.")
+    config = STRUCTURE_MODEL_REGISTRY["esmfold2_fast"]
+    model = (
+        ESMFold2Model.from_pretrained(
+            config["fast_path"],
+            load_esmc=True,
+            dtype=torch.float32,
+        )
+        .eval()
+        .cuda()
+    )
+
+    result = model.fold_protein(
+        TEST_SEQUENCE,
+        num_loops=1,
+        num_sampling_steps=1,
+        num_diffusion_samples=1,
+        seed=0,
+        ttt=True,
+        ttt_config={
+            "steps": 1,
+            "ags": 1,
+            "batch_size": 1,
+            "crop_size": 64,
+            "lora_rank": 2,
+            "lora_alpha": 1.0,
+        },
+    )
+
+    assert result.ttt_metrics is not None
+    assert len(result.ttt_metrics["losses"]) == 1
+    assert len(result.ttt_metrics["step_plddts"]) == 2
+    assert result.ttt_metrics["best_step"] in {0, 1}
+
+    del model, result
+    torch.cuda.empty_cache()


### PR DESCRIPTION
**PR Summary**

This PR adds shared, experimental test-time training support across FastPLMs using LoRA-based MLM adaptation. It introduces a reusable `FastPLMTestTimeTrainingMixin`, `TTTConfig`, lazy LoRA injection, MLM crop/mask sampling, adapter reset/restore utilities, and family-specific hooks for ESM2, ESM++, ESM3, E1, DPLM, DPLM2, ANKH, ESMFold, and ESMFold2.

ESMFold2 now supports opt-in TTT through `fold_protein(..., ttt=True)` and `fold_protein_ttt(...)`, while default inference remains unchanged and no LoRA modules are injected unless TTT is explicitly called. TTT trains only the PLM/ESMC side, not the folding trunk, confidence head, or diffusion head.

Docs and README content were updated to mark TTT as experimental, disabled by default, and potentially useful for improving structure confidence via additional test-time compute. The ProteinTTT citation was added.

Validation on the GH200 workstation:
- `test_ttt.py`: `11 passed`
- `test_esmfold2.py`: `3 passed, 4 skipped`
- fast GPU suite: `173 passed, 1 skipped, 221 deselected`

Also fixed a LoRA wrapper compatibility issue found during testing by exposing proxied `weight` and `bias` attributes for model code that introspects projection dtype/device.