### PR TITLE
Keep model mask preparation outside torch.compile

### DIFF
--- a/src/fastplms/models/e1/attention.py
+++ b/src/fastplms/models/e1/attention.py
@@ -322,11 +322,7 @@ def varlen_flex_attention_func(
     seqlens_k = cu_seqlens_k[1:] - cu_seqlens_k[:-1]  # (n,)
     block_mask = block_mask_creator(seqlens_q, seqlens_k)
 
-    packed_lengths = (
-        *(int(length) for length in seqlens_q.tolist()),
-        -1,
-        *(int(length) for length in seqlens_k.tolist()),
-    )
+    packed_lengths = _packed_lengths_cache_key(seqlens_q, seqlens_k)
     fn = _get_flex_attention_fn(
         device=query_states.device,
         dtype=query_states.dtype,
@@ -351,6 +347,21 @@ def varlen_flex_attention_func(
     return attn_output  # (b, l_q, h, d)
 
 
+@torch.compiler.disable
+def _packed_lengths_cache_key(
+    query_lengths: torch.Tensor,
+    key_lengths: torch.Tensor,
+) -> tuple[int, ...]:
+    """Convert packed lengths to an immutable Flex cache key eagerly."""
+
+    return (
+        *(int(length) for length in query_lengths.tolist()),
+        -1,
+        *(int(length) for length in key_lengths.tolist()),
+    )
+
+
+@torch.compiler.disable
 def _get_unpad_data(sequence_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, int]:
     """Return packed indices and run lengths for the non-padding sequence IDs."""
 
@@ -384,6 +395,7 @@ def _get_unpad_data(sequence_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Ten
     )
 
 
+@torch.compiler.disable
 def _unpad_input(
     query_layer: torch.Tensor,
     key_layer: torch.Tensor,

--- a/src/fastplms/models/e1/modeling_e1.py
+++ b/src/fastplms/models/e1/modeling_e1.py
@@ -135,6 +135,54 @@ def _get_logger():
     return logging.get_logger(__name__)
 
 
+@torch.compiler.disable
+def _validate_cached_global_query_start(first_sequence_id: torch.Tensor) -> None:
+    """Keep cached-query validation eager while preserving padding semantics."""
+
+    if bool(first_sequence_id.eq(-1).any()):
+        raise ValueError("E1 cached queries must start with a non-padding sequence token.")
+
+
+@torch.compiler.disable
+def _validate_biological_indices(
+    within_positions: torch.Tensor,
+    global_positions: torch.Tensor,
+    sequence_numbers: torch.Tensor,
+    config: E1Config,
+) -> None:
+    """Validate E1's sequence and position conventions outside compiled graphs."""
+
+    lowest_position, highest_position = torch.aminmax(within_positions)
+    minimum_position = int(lowest_position.item())
+    maximum_position = int(highest_position.item())
+    if minimum_position < -1 or maximum_position >= config.max_num_positions_within_seq:
+        raise ValueError(
+            "Position ids must be in the range "
+            f"[-1, {config.max_num_positions_within_seq}); got max "
+            f"{maximum_position} and min {minimum_position}"
+        )
+
+    lowest_global, highest_global = torch.aminmax(global_positions)
+    minimum_global = int(lowest_global.item())
+    maximum_global = int(highest_global.item())
+    if minimum_global < -1 or maximum_global >= config.max_num_positions_global:
+        raise ValueError(
+            "Global position ids must be in the range "
+            f"[-1, {config.max_num_positions_global}); got max "
+            f"{maximum_global} and min {minimum_global}"
+        )
+
+    lowest_sequence, highest_sequence = torch.aminmax(sequence_numbers)
+    minimum_sequence = int(lowest_sequence.item())
+    maximum_sequence = int(highest_sequence.item())
+    if minimum_sequence < -1 or maximum_sequence >= config.max_num_sequences:
+        raise ValueError(
+            "Sequence ids must be in the range "
+            f"[-1, {config.max_num_sequences}); got max "
+            f"{maximum_sequence} and min {minimum_sequence}"
+        )
+
+
 _TOKENIZER_LOAD_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
     "fastplms_e1_tokenizer_load_context",
     default=None,
@@ -319,6 +367,19 @@ class RotaryPositionalEmbedding(nn.Module):
         self.cos_cached = angles.cos()
         self.sin_cached = angles.sin()
 
+    @torch.compiler.disable
+    def _ensure_sin_cos_cache(
+        self,
+        position_ids: torch.Tensor,
+        seq_len: int | None,
+        device: torch.device,
+    ) -> None:
+        """Resize the data-dependent rotary cache outside compiled graphs."""
+
+        required_length = int(position_ids.max().item()) + 1 if seq_len is None else seq_len
+        if required_length > self.max_seq_len_cached:
+            self._set_sin_cos_cache(seq_len=required_length, device=device)
+
     def forward(
         self,
         q: torch.Tensor,
@@ -328,10 +389,7 @@ class RotaryPositionalEmbedding(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         # q, k: (b, l, h, d)
         device, dtype = q.device, q.dtype
-        seq_len = position_ids.max().item() + 1 if seq_len is None else seq_len
-
-        if seq_len > self.max_seq_len_cached:
-            self._set_sin_cos_cache(seq_len=seq_len, device=device)
+        self._ensure_sin_cos_cache(position_ids, seq_len, device)
 
         # Selecting by position inserts a head axis for broadcasting.
         idxs = position_ids.to(device)
@@ -717,8 +775,7 @@ class Attention(nn.Module):
         if cached_len < 0:
             raise ValueError(f"E1 cached KV length {kv_len} is shorter than query length {q_len}.")
         first_sequence_id = query_sequence_ids[:, :1]
-        if bool(first_sequence_id.eq(-1).any()):
-            raise ValueError("E1 cached queries must start with a non-padding sequence token.")
+        _validate_cached_global_query_start(first_sequence_id)
         cached_sequence_ids = first_sequence_id.expand(-1, cached_len)
         key_sequence_ids = torch.cat((cached_sequence_ids, query_sequence_ids), dim=-1)
         return query_sequence_ids, key_sequence_ids
@@ -1314,33 +1371,12 @@ class FAST_E1_ENCODER(E1PreTrainedModel, EmbeddingMixin):
         within_positions = within_seq_position_ids.long()
         global_positions = global_position_ids.long()
         sequence_numbers = sequence_ids.long()
-        lowest_position, highest_position = torch.aminmax(within_positions)
-        if (
-            lowest_position.item() < -1
-            or highest_position.item() >= self.config.max_num_positions_within_seq
-        ):
-            raise ValueError(
-                "Position ids must be in the range "
-                f"[-1, {self.config.max_num_positions_within_seq}); got max "
-                f"{highest_position.item()} and min {lowest_position.item()}"
-            )
-        lowest_global, highest_global = torch.aminmax(global_positions)
-        if (
-            lowest_global.item() < -1
-            or highest_global.item() >= self.config.max_num_positions_global
-        ):
-            raise ValueError(
-                "Global position ids must be in the range "
-                f"[-1, {self.config.max_num_positions_global}); got max "
-                f"{highest_global.item()} and min {lowest_global.item()}"
-            )
-        lowest_sequence, highest_sequence = torch.aminmax(sequence_numbers)
-        if lowest_sequence.item() < -1 or highest_sequence.item() >= self.config.max_num_sequences:
-            raise ValueError(
-                "Sequence ids must be in the range "
-                f"[-1, {self.config.max_num_sequences}); got max "
-                f"{highest_sequence.item()} and min {lowest_sequence.item()}"
-            )
+        _validate_biological_indices(
+            within_positions,
+            global_positions,
+            sequence_numbers,
+            self.config,
+        )
 
         if inputs_embeds is None:
             if input_ids is None:

--- a/src/fastplms/models/esm3/modeling_esm3.py
+++ b/src/fastplms/models/esm3/modeling_esm3.py
@@ -1350,12 +1350,13 @@ class MultiHeadAttention(nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        seq_id: torch.Tensor | None,
         attention_mask: torch.Tensor | None = None,
+        flex_block_mask: BlockMask | None = None,
+        mask_semantics: str = "dense",
         output_attentions: bool = False,
         effective_backend: AttentionBackend | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        # x: (b, l, d); seq_id, attention_mask: (b, l)
+        # x: (b, l, d); attention_mask: (b, 1, l, l) or (b, 1, 1, l)
         qkv = self.layernorm_qkv(x)  # (b, l, 3 * d)
         query, key, value = torch.chunk(qkv, 3, dim=-1)
         query = self.q_ln(query).to(query.dtype)
@@ -1368,13 +1369,7 @@ class MultiHeadAttention(nn.Module):
             h=self.n_heads,
         )
         query, key, value = map(reshaper, (query, key, value))  # each (b, h, l, d_h)
-
-        mask = None
-        if seq_id is not None:
-            mask = (seq_id.unsqueeze(-1) == seq_id.unsqueeze(-2)).unsqueeze(1)
-        if attention_mask is not None:
-            key_padding_mask = attention_mask[:, None, None, :]
-            mask = key_padding_mask if mask is None else mask & key_padding_mask
+        mask = attention_mask
 
         if effective_backend is None:
             effective_backend = resolve_attention_backend_for_call(
@@ -1401,15 +1396,6 @@ class MultiHeadAttention(nn.Module):
         else:
             attn_weights = None
             if effective_backend == AttentionBackend.FLEX:
-                block_mask = self._create_flex_block_mask(seq_id, attention_mask, query)
-                if seq_id is not None and attention_mask is not None:
-                    mask_semantics = "sequence_id_and_padding"
-                elif seq_id is not None:
-                    mask_semantics = "sequence_id_equality"
-                elif attention_mask is not None:
-                    mask_semantics = "padding"
-                else:
-                    mask_semantics = "dense"
                 fn = _get_flex_attention_fn(
                     device=query.device,
                     dtype=query.dtype,
@@ -1423,7 +1409,7 @@ class MultiHeadAttention(nn.Module):
                     query,
                     key,
                     value,
-                    block_mask=block_mask,
+                    block_mask=flex_block_mask,
                     scale=self.scale,
                 )
             elif effective_backend == AttentionBackend.SDPA:
@@ -1441,37 +1427,6 @@ class MultiHeadAttention(nn.Module):
             context = context.masked_fill(~mask.any(dim=-1, keepdim=True), 0.0)
         context = einops.rearrange(context, "b h s d -> b s (h d)")  # (b, l, d)
         return self.out_proj(context), attn_weights
-
-    @staticmethod
-    def _create_flex_block_mask(
-        seq_id: torch.Tensor | None,
-        attention_mask: torch.Tensor | None,
-        query: torch.Tensor,
-    ) -> BlockMask | None:
-        if seq_id is None and attention_mask is None:
-            return None
-        if create_block_mask is None:
-            raise RuntimeError(
-                "Flex Attention requested but torch.create_block_mask is unavailable."
-            )
-        batch_size, _, seq_len, _ = query.shape
-
-        def mask_mod(batch_idx, _head_idx, q_idx, kv_idx):
-            if seq_id is None:
-                return attention_mask[batch_idx, kv_idx]
-            allowed = seq_id[batch_idx, q_idx] == seq_id[batch_idx, kv_idx]
-            if attention_mask is not None:
-                allowed = allowed & attention_mask[batch_idx, kv_idx]
-            return allowed
-
-        return create_block_mask(
-            mask_mod,
-            batch_size,
-            1,
-            seq_len,
-            seq_len,
-            device=query.device,
-        )
 
 
 class GeometricReasoningOriginalImpl(nn.Module):
@@ -1683,6 +1638,8 @@ class UnifiedTransformerBlock(nn.Module):
         x: torch.Tensor,
         sequence_id: torch.Tensor | None,
         attention_mask: torch.Tensor | None,
+        flex_block_mask: BlockMask | None,
+        mask_semantics: str,
         frames: Affine3D,
         frames_mask: torch.Tensor,
         chain_id: torch.Tensor,
@@ -1693,8 +1650,9 @@ class UnifiedTransformerBlock(nn.Module):
         if self.use_plain_attn:
             plain_residual, attn_weights = self.attn(
                 x,
-                sequence_id,
                 attention_mask,
+                flex_block_mask,
+                mask_semantics,
                 output_attentions=output_attentions,
                 effective_backend=effective_backend,
             )
@@ -1772,9 +1730,17 @@ class TransformerStack(nn.Module):
             chain_id = torch.ones(size=batch_dims, dtype=torch.int64, device=x.device)
         if affine is None or affine_mask is None:
             raise ValueError("affine and affine_mask are required for ESM3 transformer calls.")
-        effective_backend = resolve_attention_backend_for_call(
-            self.attention_backend,
-            output_attentions=output_attentions,
+        attention_mask, flex_block_mask, affine_mask, mask_semantics, effective_backend = (
+            self._prepare_attention_masks(
+                sequence_id=sequence_id,
+                attention_mask=attention_mask,
+                affine_mask=affine_mask,
+                batch_size=x.shape[0],
+                seq_len=x.shape[1],
+                device=x.device,
+                attention_backend=self.attention_backend,
+                output_attentions=output_attentions,
+            )
         )
         all_hidden_states = [] if output_hidden_states else None
         all_attentions = []
@@ -1783,6 +1749,8 @@ class TransformerStack(nn.Module):
                 x,
                 sequence_id,
                 attention_mask,
+                flex_block_mask,
+                mask_semantics,
                 affine,
                 affine_mask,
                 chain_id,
@@ -1796,6 +1764,107 @@ class TransformerStack(nn.Module):
         hidden_states = tuple(all_hidden_states) if all_hidden_states is not None else None
         attentions = tuple(all_attentions) if output_attentions else None
         return self.norm(x), x, hidden_states, attentions
+
+    @staticmethod
+    @torch.compiler.disable
+    def _prepare_attention_masks(
+        sequence_id: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+        affine_mask: torch.Tensor,
+        batch_size: int,
+        seq_len: int,
+        device: torch.device,
+        attention_backend: AttentionBackend,
+        output_attentions: bool,
+    ) -> tuple[
+        torch.Tensor | None,
+        BlockMask | None,
+        torch.Tensor,
+        str,
+        AttentionBackend,
+    ]:
+        expected_mask_shape = (batch_size, seq_len)
+        if sequence_id is not None and tuple(sequence_id.shape) != expected_mask_shape:
+            raise ValueError(
+                "sequence_id must have shape (batch, sequence); "
+                f"expected {expected_mask_shape}, received {tuple(sequence_id.shape)}."
+            )
+        if attention_mask is not None:
+            if tuple(attention_mask.shape) != expected_mask_shape:
+                raise ValueError(
+                    "attention_mask must have shape (batch, sequence); "
+                    f"expected {expected_mask_shape}, received {tuple(attention_mask.shape)}."
+                )
+            if attention_mask.dtype != torch.bool and not bool(
+                torch.logical_or(attention_mask == 0, attention_mask == 1).all()
+            ):
+                raise ValueError("attention_mask must contain only boolean or 0/1 values.")
+            attention_mask = attention_mask.to(device=device, dtype=torch.bool)
+            if not bool(attention_mask.any(dim=-1).all()):
+                raise ValueError("attention_mask must keep at least one valid key per batch row.")
+            affine_mask = affine_mask & attention_mask
+
+        effective_backend = resolve_attention_backend_for_call(
+            attention_backend,
+            output_attentions=output_attentions,
+        )
+
+        dense_mask = None
+        if sequence_id is not None:
+            dense_mask = (sequence_id.unsqueeze(-1) == sequence_id.unsqueeze(-2)).unsqueeze(1)
+        if attention_mask is not None:
+            key_padding_mask = attention_mask[:, None, None, :]
+            dense_mask = key_padding_mask if dense_mask is None else dense_mask & key_padding_mask
+
+        if sequence_id is not None and attention_mask is not None:
+            mask_semantics = "sequence_id_and_padding"
+        elif sequence_id is not None:
+            mask_semantics = "sequence_id_equality"
+        elif attention_mask is not None:
+            mask_semantics = "padding"
+        else:
+            mask_semantics = "dense"
+
+        flex_block_mask = None
+        if effective_backend == AttentionBackend.FLEX and dense_mask is not None:
+            flex_block_mask = TransformerStack._create_flex_block_mask(
+                sequence_id,
+                attention_mask,
+                batch_size,
+                seq_len,
+                device,
+            )
+        return dense_mask, flex_block_mask, affine_mask, mask_semantics, effective_backend
+
+    @staticmethod
+    def _create_flex_block_mask(
+        sequence_id: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+        batch_size: int,
+        seq_len: int,
+        device: torch.device,
+    ) -> BlockMask:
+        if create_block_mask is None:
+            raise RuntimeError(
+                "Flex Attention requested but torch.create_block_mask is unavailable."
+            )
+
+        def mask_mod(batch_idx, _head_idx, q_idx, kv_idx):
+            if sequence_id is None:
+                return attention_mask[batch_idx, kv_idx]
+            allowed = sequence_id[batch_idx, q_idx] == sequence_id[batch_idx, kv_idx]
+            if attention_mask is not None:
+                allowed = allowed & attention_mask[batch_idx, kv_idx]
+            return allowed
+
+        return create_block_mask(
+            mask_mod,
+            batch_size,
+            1,
+            seq_len,
+            seq_len,
+            device=device,
+        )
 
 
 class EncodeInputs(nn.Module):
@@ -2049,26 +2118,6 @@ class ESM3Core(nn.Module):
             function_tokens,
             residue_annotation_tokens,
         )
-        expected_mask_shape = tuple(x.shape[:2])
-        if sequence_id is not None and tuple(sequence_id.shape) != expected_mask_shape:
-            raise ValueError(
-                "sequence_id must have shape (batch, sequence); "
-                f"expected {expected_mask_shape}, received {tuple(sequence_id.shape)}."
-            )
-        if attention_mask is not None:
-            if tuple(attention_mask.shape) != expected_mask_shape:
-                raise ValueError(
-                    "attention_mask must have shape (batch, sequence); "
-                    f"expected {expected_mask_shape}, received {tuple(attention_mask.shape)}."
-                )
-            if attention_mask.dtype != torch.bool and not bool(
-                torch.logical_or(attention_mask == 0, attention_mask == 1).all()
-            ):
-                raise ValueError("attention_mask must contain only boolean or 0/1 values.")
-            attention_mask = attention_mask.to(device=x.device, dtype=torch.bool)
-            if not bool(attention_mask.any(dim=-1).all()):
-                raise ValueError("attention_mask must keep at least one valid key per batch row.")
-            affine_mask = affine_mask & attention_mask
         x, embedding, hidden_states, attentions = self.transformer(
             x,
             sequence_id,

--- a/src/fastplms/models/esm3/modeling_esm3.py
+++ b/src/fastplms/models/esm3/modeling_esm3.py
@@ -1809,13 +1809,6 @@ class TransformerStack(nn.Module):
             output_attentions=output_attentions,
         )
 
-        dense_mask = None
-        if sequence_id is not None:
-            dense_mask = (sequence_id.unsqueeze(-1) == sequence_id.unsqueeze(-2)).unsqueeze(1)
-        if attention_mask is not None:
-            key_padding_mask = attention_mask[:, None, None, :]
-            dense_mask = key_padding_mask if dense_mask is None else dense_mask & key_padding_mask
-
         if sequence_id is not None and attention_mask is not None:
             mask_semantics = "sequence_id_and_padding"
         elif sequence_id is not None:
@@ -1825,8 +1818,10 @@ class TransformerStack(nn.Module):
         else:
             mask_semantics = "dense"
 
+        dense_mask = None
         flex_block_mask = None
-        if effective_backend == AttentionBackend.FLEX and dense_mask is not None:
+        has_attention_mask = sequence_id is not None or attention_mask is not None
+        if effective_backend == AttentionBackend.FLEX and has_attention_mask:
             flex_block_mask = TransformerStack._create_flex_block_mask(
                 sequence_id,
                 attention_mask,
@@ -1834,6 +1829,14 @@ class TransformerStack(nn.Module):
                 seq_len,
                 device,
             )
+        else:
+            if sequence_id is not None:
+                dense_mask = (sequence_id.unsqueeze(-1) == sequence_id.unsqueeze(-2)).unsqueeze(1)
+            if attention_mask is not None:
+                key_padding_mask = attention_mask[:, None, None, :]
+                dense_mask = (
+                    key_padding_mask if dense_mask is None else dense_mask & key_padding_mask
+                )
         return dense_mask, flex_block_mask, affine_mask, mask_semantics, effective_backend
 
     @staticmethod

--- a/src/fastplms/models/esm_plusplus/modeling_esm_plusplus.py
+++ b/src/fastplms/models/esm_plusplus/modeling_esm_plusplus.py
@@ -696,53 +696,17 @@ class TransformerStack(nn.Module):
         # Match the pinned Biohub Transformers contract: a supplied sequence_id
         # is authoritative and must encode padding as -1.  attention_mask is
         # ignored in that mode rather than intersected with the chain mask.
-        if sequence_id is None and attention_mask is not None:
-            expected_shape = (x.shape[0], x.shape[1])
-            if attention_mask.ndim != 2 or tuple(attention_mask.shape) != expected_shape:
-                raise ValueError(
-                    f"attention_mask must have shape {expected_shape}; "
-                    f"received {tuple(attention_mask.shape)}."
-                )
-            attention_mask = attention_mask.to(device=x.device, dtype=torch.bool)
-            if not bool(attention_mask.any(dim=1).all()):
-                raise ValueError("attention_mask must keep at least one valid key per batch row.")
-        effective_backend = resolve_attention_backend_for_call(
-            self.attention_backend,
-            output_attentions=bool(output_attentions),
-        )
-
-        if sequence_id is None and attention_mask is not None:
-            attention_mask_2d, attention_mask_4d, flex_block_mask = (
-                self._sequence_id_attention_masks(
-                    sequence_id=attention_mask.to(device=x.device, dtype=torch.bool),
-                    batch_size=x.shape[0],
-                    seq_len=x.shape[1],
-                    device=x.device,
-                    dtype=x.dtype,
-                    effective_backend=effective_backend,
-                )
-            )
-        elif sequence_id is None:
-            attention_mask_2d, attention_mask_4d, flex_block_mask = get_attention_mask(
-                effective_backend=effective_backend,
+        attention_mask_2d, attention_mask_4d, flex_block_mask = (
+            self._prepare_attention_masks(
+                attention_mask=attention_mask,
+                sequence_id=sequence_id,
                 batch_size=x.shape[0],
                 seq_len=x.shape[1],
                 device=x.device,
-                attention_mask=attention_mask,
                 dtype=x.dtype,
-                mask_semantics="padding",
+                output_attentions=bool(output_attentions),
             )
-        else:
-            attention_mask_2d, attention_mask_4d, flex_block_mask = (
-                self._sequence_id_attention_masks(
-                    sequence_id=sequence_id,
-                    batch_size=x.shape[0],
-                    seq_len=x.shape[1],
-                    device=x.device,
-                    dtype=x.dtype,
-                    effective_backend=effective_backend,
-                )
-            )
+        )
 
         for block in self.blocks:
             if output_hidden_states:
@@ -790,44 +754,71 @@ class TransformerStack(nn.Module):
             s_max=full_s_max,
         )
 
-    def _sequence_id_attention_masks(
+    @torch.compiler.disable
+    def _prepare_attention_masks(
         self,
-        sequence_id: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        sequence_id: torch.Tensor | None,
         batch_size: int,
         seq_len: int,
         device: torch.device,
         dtype: torch.dtype | None = None,
         effective_backend: AttentionBackend | None = None,
+        output_attentions: bool = False,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None, BlockMask | None]:
-        expected_shape = (batch_size, seq_len)
-        if sequence_id.ndim != 2 or tuple(sequence_id.shape) != expected_shape:
-            raise ValueError(
-                f"sequence_id must have shape {expected_shape}; "
-                f"received {tuple(sequence_id.shape)}."
+        mask_name = "sequence_id" if sequence_id is not None else "attention_mask"
+        mask_pattern = sequence_id if sequence_id is not None else attention_mask
+        if mask_pattern is None:
+            backend = resolve_attention_backend_for_call(
+                self.attention_backend,
+                output_attentions=output_attentions,
             )
-        if sequence_id.device != device:
-            sequence_id = sequence_id.to(device=device)
-        backend = (
-            self.attention_backend
-            if effective_backend is None
-            else resolve_attention_backend(effective_backend)
-        )
-        if sequence_id.dtype == torch.bool:
-            attention_mask_2d = sequence_id
+            return get_attention_mask(
+                effective_backend=backend,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                device=device,
+                attention_mask=None,
+                dtype=dtype,
+                mask_semantics="padding",
+            )
+
+        expected_shape = (batch_size, seq_len)
+        if mask_pattern.ndim != 2 or tuple(mask_pattern.shape) != expected_shape:
+            raise ValueError(
+                f"{mask_name} must have shape {expected_shape}; "
+                f"received {tuple(mask_pattern.shape)}."
+            )
+        if mask_pattern.device != device:
+            mask_pattern = mask_pattern.to(device=device)
+        if sequence_id is None:
+            mask_pattern = mask_pattern.to(dtype=torch.bool)
+        if mask_pattern.dtype == torch.bool:
+            attention_mask_2d = mask_pattern
             # Biohub's boolean single-chain form groups biological positions
             # together and padding positions together. Padding queries remain
             # finite without allowing their states to enter residue attention.
-            attention_mask_4d = sequence_id[:, None, :, None] == sequence_id[:, None, None, :]
-        else:
-            attention_mask_2d = sequence_id != -1
-            attention_mask_4d = (sequence_id.unsqueeze(-1) == sequence_id.unsqueeze(-2)).unsqueeze(
-                1
+            attention_mask_4d = (
+                mask_pattern[:, None, :, None] == mask_pattern[:, None, None, :]
             )
+        else:
+            attention_mask_2d = mask_pattern != -1
+            attention_mask_4d = (
+                mask_pattern.unsqueeze(-1) == mask_pattern.unsqueeze(-2)
+            ).unsqueeze(1)
         if not bool(attention_mask_2d.any(dim=1).all()):
             raise ValueError("attention_mask must keep at least one valid key per batch row.")
+        backend = (
+            resolve_attention_backend_for_call(
+                self.attention_backend,
+                output_attentions=output_attentions,
+            )
+            if effective_backend is None
+            else resolve_attention_backend(effective_backend)
+        )
 
         if backend.is_flash:
-            if sequence_id.dtype != torch.bool:
+            if mask_pattern.dtype != torch.bool:
                 raise ValueError(
                     "ESM++ FlashAttention only supports boolean sequence_id padding masks. "
                     "Use eager, sdpa, or flex_attention for chain-aware integer sequence_id "
@@ -836,22 +827,22 @@ class TransformerStack(nn.Module):
             return attention_mask_2d, attention_mask_4d, None
 
         if backend == AttentionBackend.FLEX:
-            if sequence_id.dtype == torch.bool:
+            if mask_pattern.dtype == torch.bool:
 
                 def mask_mod(batch_idx, head_idx, q_idx, kv_idx):
                     del head_idx
-                    return sequence_id[batch_idx, q_idx] == sequence_id[batch_idx, kv_idx]
+                    return mask_pattern[batch_idx, q_idx] == mask_pattern[batch_idx, kv_idx]
 
             else:
 
                 def mask_mod(batch_idx, head_idx, q_idx, kv_idx):
                     del head_idx
-                    q_id = sequence_id[batch_idx, q_idx]
-                    kv_id = sequence_id[batch_idx, kv_idx]
+                    q_id = mask_pattern[batch_idx, q_idx]
+                    kv_id = mask_pattern[batch_idx, kv_idx]
                     return q_id == kv_id
 
             flex_block_mask = _get_flex_block_mask(
-                mask_pattern=sequence_id,
+                mask_pattern=mask_pattern,
                 batch_size=batch_size,
                 query_length=seq_len,
                 key_value_length=seq_len,
@@ -859,7 +850,7 @@ class TransformerStack(nn.Module):
                 dtype=dtype,
                 mask_semantics=(
                     "boolean_sequence_id"
-                    if sequence_id.dtype == torch.bool
+                    if mask_pattern.dtype == torch.bool
                     else "integer_sequence_id"
                 ),
                 mask_mod=mask_mod,

--- a/src/fastplms/models/esm_plusplus/modeling_esm_plusplus.py
+++ b/src/fastplms/models/esm_plusplus/modeling_esm_plusplus.py
@@ -793,8 +793,13 @@ class TransformerStack(nn.Module):
             mask_pattern = mask_pattern.to(device=device)
         if sequence_id is None:
             mask_pattern = mask_pattern.to(dtype=torch.bool)
+        attention_mask_2d = (
+            mask_pattern if mask_pattern.dtype == torch.bool else mask_pattern != -1
+        )
+        if not bool(attention_mask_2d.any(dim=1).all()):
+            raise ValueError("attention_mask must keep at least one valid key per batch row.")
+
         if mask_pattern.dtype == torch.bool:
-            attention_mask_2d = mask_pattern
             # Biohub's boolean single-chain form groups biological positions
             # together and padding positions together. Padding queries remain
             # finite without allowing their states to enter residue attention.
@@ -802,12 +807,9 @@ class TransformerStack(nn.Module):
                 mask_pattern[:, None, :, None] == mask_pattern[:, None, None, :]
             )
         else:
-            attention_mask_2d = mask_pattern != -1
             attention_mask_4d = (
                 mask_pattern.unsqueeze(-1) == mask_pattern.unsqueeze(-2)
             ).unsqueeze(1)
-        if not bool(attention_mask_2d.any(dim=1).all()):
-            raise ValueError("attention_mask must keep at least one valid key per batch row.")
         backend = (
             resolve_attention_backend_for_call(
                 self.attention_backend,

--- a/src/fastplms/models/esmfold2/modeling_esmfold2_common.py
+++ b/src/fastplms/models/esmfold2/modeling_esmfold2_common.py
@@ -1581,6 +1581,22 @@ class SWAAtomTransformer(nn.Module):
 # ===========================================================================
 
 
+@torch.compiler.disable
+def _prepare_atom_encoder_metadata(
+    atom_attention_mask: Tensor,
+    atom_to_token: Tensor,
+    num_diffusion_samples: int,
+) -> tuple[Tensor, Tensor, Tensor, int, int]:
+    """Prepare mask-derived atom metadata outside compiled diffusion graphs."""
+    mask_exp = atom_attention_mask.repeat_interleave(num_diffusion_samples, 0)
+    seqlens = mask_exp.sum(dim=-1, dtype=torch.int32)
+    indices = torch.nonzero(mask_exp.flatten(), as_tuple=False).flatten()
+    max_seqlen = int(seqlens.max().item())
+    cu_seqlens = F.pad(torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0))
+    n_tokens = int(atom_to_token.max().item()) + 1
+    return mask_exp, indices, cu_seqlens, max_seqlen, n_tokens
+
+
 class ESMFold2AtomEncoder(nn.Module):
     """Encode atom inputs with normalization and sliding-window attention.
 
@@ -1677,13 +1693,14 @@ class ESMFold2AtomEncoder(nn.Module):
             cos, sin = self.atom_transformer._build_3d_rope(ref_pos, ref_space_uid)
             cos = cos.repeat_interleave(num_diffusion_samples, 0)
             sin = sin.repeat_interleave(num_diffusion_samples, 0)
-            mask_exp = atom_attention_mask.repeat_interleave(num_diffusion_samples, 0)
-            seqlens = mask_exp.sum(dim=-1, dtype=torch.int32)
-            indices = torch.nonzero(mask_exp.flatten(), as_tuple=False).flatten()
-            max_seqlen = int(seqlens.max().item())
-            cu_seqlens = F.pad(torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0))
+            mask_exp, indices, cu_seqlens, max_seqlen, n_tokens = (
+                _prepare_atom_encoder_metadata(
+                    atom_attention_mask,
+                    atom_to_token,
+                    num_diffusion_samples,
+                )
+            )
             attention_params = (cos, sin, indices, cu_seqlens, max_seqlen)
-            n_tokens = int(atom_to_token.max().item()) + 1
             if layer_cache is not None:
                 layer_cache["c_base"] = c_base
                 layer_cache["attention_params"] = attention_params

--- a/tests/cpu/test_hf_base_model_contracts.py
+++ b/tests/cpu/test_hf_base_model_contracts.py
@@ -365,8 +365,9 @@ def test_esmc_sequence_id_is_authoritative_for_chain_and_padding_masks() -> None
         ).last_hidden_state
 
     torch.testing.assert_close(actual, expected, rtol=0.0, atol=0.0)
-    mask_2d, mask_4d, block_mask = model.transformer._sequence_id_attention_masks(
-        sequence_id,
+    mask_2d, mask_4d, block_mask = model.transformer._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=sequence_id,
         batch_size=1,
         seq_len=6,
         device=input_ids.device,

--- a/tests/unit/test_attention_interfaces.py
+++ b/tests/unit/test_attention_interfaces.py
@@ -1494,16 +1494,18 @@ def test_esmplusplus_flex_sequence_masks_share_exact_bounded_cache(
         ((True, True, False, False), (True, False, True, False))
     )
 
-    *_, first = stack._sequence_id_attention_masks(
-        boolean_pattern,
+    *_, first = stack._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=boolean_pattern,
         batch_size=2,
         seq_len=4,
         device=torch.device("cpu"),
         dtype=torch.bfloat16,
         effective_backend=AttentionBackend.FLEX,
     )
-    *_, repeated = stack._sequence_id_attention_masks(
-        boolean_pattern.clone(),
+    *_, repeated = stack._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=boolean_pattern.clone(),
         batch_size=2,
         seq_len=4,
         device=torch.device("cpu"),
@@ -1513,8 +1515,9 @@ def test_esmplusplus_flex_sequence_masks_share_exact_bounded_cache(
     assert repeated is first
     assert len(created) == 1
 
-    *_, different_dtype = stack._sequence_id_attention_masks(
-        boolean_pattern,
+    *_, different_dtype = stack._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=boolean_pattern,
         batch_size=2,
         seq_len=4,
         device=torch.device("cpu"),
@@ -1524,8 +1527,9 @@ def test_esmplusplus_flex_sequence_masks_share_exact_bounded_cache(
     assert different_dtype is not first
 
     chain_pattern = torch.tensor(((0, 0, -1, -1), (0, 1, 1, -1)))
-    *_, chain_mask = stack._sequence_id_attention_masks(
-        chain_pattern,
+    *_, chain_mask = stack._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=chain_pattern,
         batch_size=2,
         seq_len=4,
         device=torch.device("cpu"),
@@ -1536,8 +1540,9 @@ def test_esmplusplus_flex_sequence_masks_share_exact_bounded_cache(
     assert len(created) == 3
     assert len(_core._flex_block_masks) == 2
 
-    *_, rebuilt = stack._sequence_id_attention_masks(
-        boolean_pattern,
+    *_, rebuilt = stack._prepare_attention_masks(
+        attention_mask=None,
+        sequence_id=boolean_pattern,
         batch_size=2,
         seq_len=4,
         device=torch.device("cpu"),

--- a/tests/unit/test_attention_regressions.py
+++ b/tests/unit/test_attention_regressions.py
@@ -592,6 +592,49 @@ def test_esm3_sequence_id_grouping_combines_with_public_padding_mask() -> None:
     assert torch.count_nonzero(attention_weights[0, :, :2, 2:4]) == 0
 
 
+def test_esm3_flex_mask_preparation_does_not_construct_dense_pairwise_mask(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SequenceIdWithoutPairwiseOperations:
+        shape = (2, 4)
+
+        def unsqueeze(self, _dim: int) -> torch.Tensor:
+            raise AssertionError("Flex mask preparation must not construct a dense pairwise mask")
+
+    sequence_id = SequenceIdWithoutPairwiseOperations()
+    affine_mask = torch.ones(2, 4, dtype=torch.bool)
+    expected_block_mask = object()
+
+    def create_flex_block_mask(*args: object) -> object:
+        assert args == (sequence_id, None, 2, 4, torch.device("cpu"))
+        return expected_block_mask
+
+    monkeypatch.setattr(
+        esm3_module.TransformerStack,
+        "_create_flex_block_mask",
+        staticmethod(create_flex_block_mask),
+    )
+
+    dense_mask, block_mask, prepared_affine_mask, mask_semantics, effective_backend = (
+        esm3_module.TransformerStack._prepare_attention_masks(
+            sequence_id=sequence_id,
+            attention_mask=None,
+            affine_mask=affine_mask,
+            batch_size=2,
+            seq_len=4,
+            device=torch.device("cpu"),
+            attention_backend=AttentionBackend.FLEX,
+            output_attentions=False,
+        )
+    )
+
+    assert dense_mask is None
+    assert block_mask is expected_block_mask
+    assert prepared_affine_mask is affine_mask
+    assert mask_semantics == "sequence_id_equality"
+    assert effective_backend == AttentionBackend.FLEX
+
+
 def test_esm3_builds_intersected_attention_masks_outside_torch_compile(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/test_attention_regressions.py
+++ b/tests/unit/test_attention_regressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 import pytest
 import torch
+from collections.abc import Callable
 from types import SimpleNamespace
 from transformers.models.esm.configuration_esm import EsmConfig
 
@@ -126,6 +127,56 @@ def test_esmplusplus_rejects_empty_attention_rows_without_fallback_or_mutation()
 
     assert captured == []
     assert stack.attention_backend == configured_backend
+
+
+def test_esmplusplus_builds_attention_masks_outside_torch_compile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stack = TransformerStack(d_model=8, n_heads=2, n_layers=1, attn_backend="sdpa").eval()
+    hidden_states = torch.randn(2, 4, 8)  # (b=2, l=4, d=8)
+    first_mask = torch.tensor(((1, 1, 0, 0), (1, 1, 1, 0)))  # (b, l)
+    second_mask = torch.tensor(((1, 1, 1, 0), (1, 0, 0, 0)))  # (b, l)
+    expected_first = stack(hidden_states, attention_mask=first_mask).last_hidden_state
+    expected_second = stack(hidden_states, attention_mask=second_mask).last_hidden_state
+    compiled_graphs: list[torch.fx.GraphModule] = []
+
+    def counting_backend(
+        graph_module: torch.fx.GraphModule,
+        example_inputs: list[torch.Tensor],
+    ) -> Callable[..., object]:
+        del example_inputs
+        compiled_graphs.append(graph_module)
+        return graph_module.forward
+
+    compiled_stack = torch.compile(stack, backend=counting_backend, dynamic=False)
+    try:
+        actual_first = compiled_stack(
+            hidden_states,
+            attention_mask=first_mask,
+        ).last_hidden_state
+        first_compile_count = len(compiled_graphs)
+        actual_second = compiled_stack(
+            hidden_states,
+            attention_mask=second_mask,
+        ).last_hidden_state
+
+        assert first_compile_count > 0
+        assert len(compiled_graphs) == first_compile_count
+        torch.testing.assert_close(actual_first, expected_first)
+        torch.testing.assert_close(actual_second, expected_second)
+        with pytest.raises(
+            ValueError,
+            match="attention_mask must keep at least one valid key per batch row",
+        ):
+            compiled_stack(
+                hidden_states,
+                attention_mask=torch.tensor(((1, 1, 0, 0), (0, 0, 0, 0))),
+            )
+    finally:
+        torch.compiler.reset()
+
+    captured = capsys.readouterr()
+    assert "Graph break from `Tensor.item()`" not in captured.err
 
 
 def _assert_masked_output_attentions_fallback(encoder: torch.nn.Module) -> None:
@@ -670,7 +721,8 @@ def test_esmplusplus_chain_masks_fail_closed_without_assertions(
     stack = TransformerStack(d_model=8, n_heads=2, n_layers=1, attn_backend="sdpa")
 
     with pytest.raises(ValueError, match=r"sequence_id must have shape \(2, 4\)"):
-        stack._sequence_id_attention_masks(
+        stack._prepare_attention_masks(
+            attention_mask=None,
             sequence_id=torch.ones(2, 4, 1, dtype=torch.bool),
             batch_size=2,
             seq_len=4,
@@ -679,7 +731,8 @@ def test_esmplusplus_chain_masks_fail_closed_without_assertions(
 
     stack.attention_backend = AttentionBackend.FLASH_ATTENTION_3
     with pytest.raises(ValueError, match="only supports boolean sequence_id"):
-        stack._sequence_id_attention_masks(
+        stack._prepare_attention_masks(
+            attention_mask=None,
             sequence_id=torch.zeros(2, 4, dtype=torch.long),
             batch_size=2,
             seq_len=4,
@@ -689,7 +742,8 @@ def test_esmplusplus_chain_masks_fail_closed_without_assertions(
     stack.attention_backend = AttentionBackend.FLEX_ATTENTION
     monkeypatch.setattr(_core, "create_block_mask", None)
     with pytest.raises(RuntimeError, match="create_block_mask is unavailable"):
-        stack._sequence_id_attention_masks(
+        stack._prepare_attention_masks(
+            attention_mask=None,
             sequence_id=torch.ones(2, 4, dtype=torch.bool),
             batch_size=2,
             seq_len=4,

--- a/tests/unit/test_attention_regressions.py
+++ b/tests/unit/test_attention_regressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import warnings
 import pytest
 import torch
@@ -589,6 +590,123 @@ def test_esm3_sequence_id_grouping_combines_with_public_padding_mask() -> None:
     masked_weights = attention_weights.masked_select(~expected_mask.expand_as(attention_weights))
     assert torch.equal(masked_weights, torch.zeros_like(masked_weights))
     assert torch.count_nonzero(attention_weights[0, :, :2, 2:4]) == 0
+
+
+def test_esm3_builds_intersected_attention_masks_outside_torch_compile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    torch.manual_seed(41)
+    model = FastESM3Model(
+        FastESM3Config(
+            hidden_size=8,
+            num_attention_heads=2,
+            num_vector_heads=2,
+            num_hidden_layers=2,
+            attn_backend="sdpa",
+        )
+    ).eval()
+    input_ids = torch.tensor(((0, 3, 4, 2, 1), (0, 6, 7, 2, 1)))  # (b=2, l=5)
+    sequence_id = torch.tensor(((0, 0, 1, 1, -1), (0, 1, 1, 1, -1)))  # (b, l)
+    first_mask = torch.tensor(((1, 1, 1, 1, 0), (1, 1, 1, 1, 0)))  # (b, l)
+    second_mask = torch.tensor(((1, 1, 1, 0, 0), (1, 1, 0, 1, 0)))  # (b, l)
+    structure_coords = torch.randn(2, 5, 3, 3)  # (b, l, backbone_atom=3, xyz=3)
+    structure_coords[:, 2] = torch.nan
+
+    affine_mask = torch.tensor(((1, 1, 0, 1, 1), (1, 0, 1, 1, 1)), dtype=torch.bool)
+    dense_mask, block_mask, prepared_affine_mask, mask_semantics, effective_backend = (
+        model.esm3.transformer._prepare_attention_masks(
+            sequence_id=sequence_id,
+            attention_mask=first_mask,
+            affine_mask=affine_mask,
+            batch_size=2,
+            seq_len=5,
+            device=torch.device("cpu"),
+            attention_backend=AttentionBackend.SDPA,
+            output_attentions=False,
+        )
+    )
+    expected_dense_mask = (
+        sequence_id.unsqueeze(-1).eq(sequence_id.unsqueeze(-2)).unsqueeze(1)
+        & first_mask.bool()[:, None, None, :]
+    )
+    assert torch.equal(dense_mask, expected_dense_mask)
+    assert block_mask is None
+    assert torch.equal(prepared_affine_mask, affine_mask & first_mask.bool())
+    assert mask_semantics == "sequence_id_and_padding"
+    assert effective_backend == AttentionBackend.SDPA
+
+    with warnings.catch_warnings(record=True) as caught_warnings, pytest.raises(
+        ValueError,
+        match="attention_mask must keep at least one valid key per batch row",
+    ):
+        model.esm3.transformer._prepare_attention_masks(
+            sequence_id=sequence_id,
+            attention_mask=torch.zeros_like(first_mask),
+            affine_mask=affine_mask,
+            batch_size=2,
+            seq_len=5,
+            device=torch.device("cpu"),
+            attention_backend=AttentionBackend.SDPA,
+            output_attentions=True,
+        )
+    assert not caught_warnings
+
+    call = functools.partial(
+        model,
+        input_ids=input_ids,
+        sequence_id=sequence_id,
+        structure_coords=structure_coords,
+    )
+    with torch.no_grad():
+        expected_first = call(attention_mask=first_mask).last_hidden_state
+        expected_second = call(attention_mask=second_mask).last_hidden_state
+
+    compiled_graphs: list[torch.fx.GraphModule] = []
+
+    def counting_backend(
+        graph_module: torch.fx.GraphModule,
+        example_inputs: list[torch.Tensor],
+    ) -> Callable[..., object]:
+        del example_inputs
+        compiled_graphs.append(graph_module)
+        return graph_module.forward
+
+    compiled_model = torch.compile(model, backend=counting_backend, dynamic=False)
+    try:
+        with torch.no_grad():
+            actual_first = compiled_model(
+                input_ids=input_ids,
+                sequence_id=sequence_id,
+                structure_coords=structure_coords,
+                attention_mask=first_mask,
+            ).last_hidden_state
+            first_compile_count = len(compiled_graphs)
+            actual_second = compiled_model(
+                input_ids=input_ids,
+                sequence_id=sequence_id,
+                structure_coords=structure_coords,
+                attention_mask=second_mask,
+            ).last_hidden_state
+
+        assert first_compile_count > 0
+        assert len(compiled_graphs) == first_compile_count
+        torch.testing.assert_close(actual_first, expected_first)
+        torch.testing.assert_close(actual_second, expected_second)
+        with pytest.raises(
+            ValueError,
+            match="attention_mask must keep at least one valid key per batch row",
+        ):
+            compiled_model(
+                input_ids=input_ids,
+                sequence_id=sequence_id,
+                structure_coords=structure_coords,
+                attention_mask=torch.tensor(((1, 1, 1, 1, 0), (0, 0, 0, 0, 0))),
+            )
+    finally:
+        torch.compiler.reset()
+
+    captured = capsys.readouterr()
+    assert "Graph break from `Tensor.item()`" not in captured.err
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_e1_cache_contract.py
+++ b/tests/unit/test_e1_cache_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 import torch
 import torch.nn.functional as F
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +15,7 @@ from transformers import PreTrainedModel
 from transformers.modeling_outputs import ModelOutput
 
 from fastplms.models.e1 import modeling_e1 as e1_modeling
+from fastplms.models.e1.attention import _get_unpad_data, _packed_lengths_cache_key
 from fastplms.models.e1.cache import DynamicCache, KVCache
 from fastplms.models.e1.modeling_e1 import (
     Attention,
@@ -260,6 +262,114 @@ def _tiny_e1_batch() -> dict[str, torch.Tensor]:
         "global_position_ids": torch.arange(4).unsqueeze(0),
         "sequence_ids": torch.zeros(1, 4, dtype=torch.long),
     }
+
+
+def test_e1_sdpa_scalar_validation_runs_outside_torch_compile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    model = E1Model(_tiny_e1_config()).eval()
+    first_batch = _tiny_e1_batch()
+    second_batch = {
+        **_tiny_e1_batch(),
+        "within_seq_position_ids": torch.tensor([[0, 1, 0, 1]]),
+        "sequence_ids": torch.tensor([[0, 0, 1, 1]]),
+    }
+
+    def run(
+        input_ids: torch.Tensor,
+        within_seq_position_ids: torch.Tensor,
+        global_position_ids: torch.Tensor,
+        sequence_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        return model(
+            input_ids=input_ids,
+            within_seq_position_ids=within_seq_position_ids,
+            global_position_ids=global_position_ids,
+            sequence_ids=sequence_ids,
+            use_cache=False,
+            output_hidden_states=False,
+        ).last_hidden_state
+
+    with torch.inference_mode():
+        expected_first = run(**first_batch)
+        expected_second = run(**second_batch)
+
+    compiled_graphs: list[torch.fx.GraphModule] = []
+
+    def counting_backend(
+        graph_module: torch.fx.GraphModule,
+        example_inputs: list[torch.Tensor],
+    ) -> Callable[..., object]:
+        del example_inputs
+        compiled_graphs.append(graph_module)
+        return graph_module.forward
+
+    compiled_run = torch.compile(run, backend=counting_backend, dynamic=False)
+    try:
+        with torch.inference_mode():
+            actual_first = compiled_run(**first_batch)
+            first_compile_count = len(compiled_graphs)
+            actual_second = compiled_run(**second_batch)
+
+            assert first_compile_count > 0
+            assert len(compiled_graphs) == first_compile_count
+            torch.testing.assert_close(actual_first, expected_first)
+            torch.testing.assert_close(actual_second, expected_second)
+            with pytest.raises(ValueError, match="Sequence ids must be in the range"):
+                compiled_run(
+                    **{
+                        **first_batch,
+                        "sequence_ids": torch.full(
+                            (1, 4),
+                            model.config.max_num_sequences,
+                        ),
+                    }
+                )
+    finally:
+        torch.compiler.reset()
+
+    captured = capsys.readouterr()
+    assert "Graph break from `Tensor.item()`" not in captured.err
+
+
+def test_e1_cached_query_and_packed_metadata_run_outside_torch_compile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    attention = _tiny_attention(AttentionLayerType.GLOBAL)
+    compiled_cached_ids = torch.compile(
+        attention._cached_global_sequence_ids,
+        backend="eager",
+        dynamic=False,
+    )
+
+    def packed_metadata(
+        sequence_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, int, tuple[int, ...]]:
+        indices, cumulative_lengths, maximum_length = _get_unpad_data(sequence_ids)
+        sequence_lengths = cumulative_lengths[1:] - cumulative_lengths[:-1]
+        cache_key = _packed_lengths_cache_key(sequence_lengths, sequence_lengths)
+        return indices, cumulative_lengths, maximum_length, cache_key
+
+    compiled_metadata = torch.compile(packed_metadata, backend="eager", dynamic=False)
+    try:
+        query_ids, key_ids = compiled_cached_ids(torch.tensor([[2, 2]]), 5)
+        assert torch.equal(query_ids, torch.tensor([[2, 2]]))
+        assert torch.equal(key_ids, torch.tensor([[2, 2, 2, 2, 2]]))
+        with pytest.raises(ValueError, match="must start with a non-padding"):
+            compiled_cached_ids(torch.tensor([[-1, 2]]), 5)
+
+        indices, cumulative_lengths, maximum_length, cache_key = compiled_metadata(
+            torch.tensor([[0, 0, 1, -1], [0, 0, 0, -1]])
+        )
+        assert torch.equal(indices, torch.tensor([0, 1, 2, 4, 5, 6]))
+        assert torch.equal(cumulative_lengths, torch.tensor([0, 2, 3, 6], dtype=torch.int32))
+        assert maximum_length == 3
+        assert cache_key == (2, 1, 3, -1, 2, 1, 3)
+    finally:
+        torch.compiler.reset()
+
+    captured = capsys.readouterr()
+    assert "Graph break from `Tensor.item()`" not in captured.err
 
 
 def test_e1_config_round_trip_preserves_cache_policy(tmp_path: Path) -> None:

--- a/tests/unit/test_esmfold2_atom_encoder_compile.py
+++ b/tests/unit/test_esmfold2_atom_encoder_compile.py
@@ -1,0 +1,89 @@
+"""CPU compile regressions for ESMFold2 atom metadata preparation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from fastplms.models.esmfold2.modeling_esmfold2_common import (
+    CHAR_VOCAB_SIZE,
+    MAX_ATOMIC_NUMBER,
+    MAX_CHARS,
+    ESMFold2AtomEncoder,
+)
+
+
+def _atom_encoder_inputs() -> dict[str, torch.Tensor | int]:
+    batch_size = 1
+    n_atoms = 4
+    num_diffusion_samples = 2
+    return {
+        "ref_pos": torch.randn(batch_size, n_atoms, 3),
+        "atom_attention_mask": torch.tensor([[1, 1, 1, 0]], dtype=torch.float32),
+        "ref_space_uid": torch.tensor([[0, 0, 1, 1]]),
+        "ref_charge": torch.zeros(batch_size, n_atoms),
+        "ref_element": torch.zeros(batch_size, n_atoms, MAX_ATOMIC_NUMBER),
+        "ref_atom_name_chars": torch.zeros(
+            batch_size,
+            n_atoms,
+            MAX_CHARS,
+            CHAR_VOCAB_SIZE,
+        ),
+        "atom_to_token": torch.tensor([[0, 0, 2, 2]]),
+        "r_l": torch.randn(batch_size * num_diffusion_samples, n_atoms, 3),
+        "num_diffusion_samples": num_diffusion_samples,
+    }
+
+
+def test_atom_encoder_mask_metadata_preserves_compiled_outputs(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    torch.manual_seed(2026)
+    encoder = ESMFold2AtomEncoder(
+        d_atom=8,
+        d_token=6,
+        n_blocks=0,
+        n_heads=1,
+    ).eval()
+    inputs = _atom_encoder_inputs()
+
+    with torch.no_grad():
+        expected = encoder(**inputs)
+
+    compiled_graphs: list[torch.fx.GraphModule] = []
+
+    def counting_backend(
+        graph_module: torch.fx.GraphModule,
+        example_inputs: list[torch.Tensor],
+    ) -> Callable[..., object]:
+        del example_inputs
+        compiled_graphs.append(graph_module)
+        return graph_module.forward
+
+    compiled_encoder = torch.compile(encoder, backend=counting_backend, dynamic=False)
+    try:
+        with torch.no_grad():
+            actual = compiled_encoder(**inputs)
+    finally:
+        torch.compiler.reset()
+
+    assert compiled_graphs
+    for actual_tensor, expected_tensor in zip(actual[:3], expected[:3], strict=True):
+        torch.testing.assert_close(actual_tensor, expected_tensor)
+
+    actual_params = actual[3]
+    expected_params = expected[3]
+    torch.testing.assert_close(actual_params[0], expected_params[0])
+    torch.testing.assert_close(actual_params[1], expected_params[1])
+    torch.testing.assert_close(actual_params[2], expected_params[2])
+    torch.testing.assert_close(actual_params[3], expected_params[3])
+    assert actual_params[4] == expected_params[4] == 3
+    assert actual_params[2].tolist() == [0, 1, 2, 4, 5, 6]
+    assert actual_params[3].tolist() == [0, 3, 6]
+    assert actual[0].shape == (2, 3, 6)
+    torch.testing.assert_close(actual[0][:, 1], torch.zeros_like(actual[0][:, 1]))
+
+    captured = capsys.readouterr()
+    assert "Graph break from `Tensor.item()`" not in captured.err

--- a/tests/unit/test_esmplusplus_masking.py
+++ b/tests/unit/test_esmplusplus_masking.py
@@ -70,6 +70,41 @@ def test_esmplusplus_boolean_sequence_id_matches_biohub_equality_mask() -> None:
     assert block_mask is None
 
 
+def test_esmplusplus_rejects_invalid_attention_mask_before_pairwise_construction() -> None:
+    class InvalidMask:
+        ndim = 2
+        shape = (1, 4)
+        device = torch.device("cpu")
+        dtype = torch.bool
+
+        def to(self, **kwargs):
+            assert kwargs == {"dtype": torch.bool}
+            return self
+
+        def any(self, *, dim: int) -> torch.Tensor:
+            assert dim == 1
+            return torch.tensor([False])
+
+        def __getitem__(self, _key):
+            raise AssertionError("pairwise mask construction must follow row validation")
+
+    stack = TransformerStack(
+        d_model=16,
+        n_heads=4,
+        n_layers=1,
+        attn_backend="eager",
+    )
+
+    with pytest.raises(ValueError, match="at least one valid key per batch row"):
+        stack._prepare_attention_masks(
+            attention_mask=InvalidMask(),
+            sequence_id=None,
+            batch_size=1,
+            seq_len=4,
+            device=torch.device("cpu"),
+        )
+
+
 @pytest.mark.parametrize("model_class", (ESMplusplusModel, ESMplusplusForMaskedLM))
 def test_esmplusplus_embedding_helper_infers_padding_mask(
     model_class: type[ESMplusplusModel] | type[ESMplusplusForMaskedLM],

--- a/tests/unit/test_esmplusplus_masking.py
+++ b/tests/unit/test_esmplusplus_masking.py
@@ -56,7 +56,8 @@ def test_esmplusplus_boolean_sequence_id_matches_biohub_equality_mask() -> None:
     )
     sequence_id = torch.tensor([[True, True, True, False, False]])  # (b=1, l=5)
 
-    mask_2d, mask_4d, block_mask = stack._sequence_id_attention_masks(
+    mask_2d, mask_4d, block_mask = stack._prepare_attention_masks(
+        attention_mask=None,
         sequence_id=sequence_id,
         batch_size=1,
         seq_len=5,


### PR DESCRIPTION
## Summary

- keep ESM++ mask validation and backend mask construction behind one intentional `torch.compiler.disable` boundary, and reject empty rows before quadratic pairwise-mask allocation
- prepare ESM3 dense, geometric, and Flex masks once per transformer-stack call while preserving `sequence_id ∩ attention_mask` and `affine_mask ∩ attention_mask` semantics
- isolate E1 biological-index validation, rotary cache sizing, cached-query validation, and packed Flash/Flex metadata from compiled graphs
- isolate ESMFold2 atom-mask metadata extraction from the compiled diffusion module
- add CPU eager/compiled parity, stable compile-count, validation-order, and no-`Tensor.item()` diagnostic regressions

## Root cause

Several model-family forwards converted mask-derived tensors to Python scalars or booleans inside compiled regions. TorchDynamo therefore emitted data-dependent graph breaks or specialized on mask contents. Each family has a distinct masking contract, so the fixes use narrow eager preparation boundaries instead of a shared mechanical rewrite.

## Impact

Mask validation and metadata materialization now run eagerly at explicit boundaries while the numerical transformer and diffusion bodies remain compiled. ESM3 reuses one prepared dense or Flex mask across all layers. Invalid masks fail before backend fallback warnings, and ESM++ rejects empty rows before constructing an O(L²) pairwise mask.

## Validation

- combined affected FastPLMs suite: 197 passed; the remaining ESM3 Flex parity test could not initialize CUDA because the local container has no NVIDIA driver
- post-review focused rerun: 128 passed, with that CUDA-dependent test deselected
- downstream ProJEPA integration suite from the original change: 77 passed
- Ruff 0.16.0 and `git diff --check`: passed
- independent final diff review: no remaining findings

Flex GPU execution was not rerun in this CPU-only environment.
